### PR TITLE
feat(devkit): improve performance, UI, and thread safety

### DIFF
--- a/src/utils/shader_compiler.hpp
+++ b/src/utils/shader_compiler.hpp
@@ -19,31 +19,44 @@
 
 namespace renodx::utils::shader::compiler {
 
+static std::mutex s_mutex_shader_compiler;
+
 inline std::optional<std::string> DisassembleShaderFXC(void* data, size_t size, LPCWSTR library = L"D3DCompiler_47.dll") {
   std::optional<std::string> result;
 
-  HMODULE d3d_compiler = LoadLibraryW(library);
-  if (d3d_compiler != nullptr) {
-    // NOLINTNEXTLINE(google-readability-casting)
-    auto d3d_disassemble = pD3DDisassemble(GetProcAddress(d3d_compiler, "D3DDisassemble"));
-
-    if (d3d_disassemble != nullptr) {
-      CComPtr<ID3DBlob> out_blob;
-      if (SUCCEEDED(d3d_disassemble(
-              data,
-              size,
-              D3D_DISASM_ENABLE_INSTRUCTION_NUMBERING | D3D_DISASM_ENABLE_INSTRUCTION_OFFSET,
-              nullptr,
-              &out_blob))) {
-        result = {reinterpret_cast<char*>(out_blob->GetBufferPointer()), out_blob->GetBufferSize()};
-      }
+  // TODO: unify this with "CompileShaderFromFileFXC()", as it loads the same dll.
+  static std::unordered_map<LPCWSTR, pD3DDisassemble> d3d_disassemble;
+  {
+    const std::lock_guard<std::mutex> lock(s_mutex_shader_compiler);
+    static std::unordered_map<LPCWSTR, HMODULE> d3d_compiler;
+    d3d_compiler[library] = LoadLibraryW(library);
+    if (d3d_compiler[library] != nullptr) {
+      // NOLINTNEXTLINE(google-readability-casting)
+      d3d_disassemble[library] = pD3DDisassemble(GetProcAddress(d3d_compiler[library], "D3DDisassemble"));
     }
-    FreeLibrary(d3d_compiler);
   }
+
+  if (d3d_disassemble[library] != nullptr) {
+    CComPtr<ID3DBlob> out_blob;
+    if (SUCCEEDED(d3d_disassemble[library](
+            data,
+            size,
+            D3D_DISASM_ENABLE_INSTRUCTION_NUMBERING | D3D_DISASM_ENABLE_INSTRUCTION_OFFSET,
+            nullptr,
+            &out_blob))) {
+      result = {reinterpret_cast<char*>(out_blob->GetBufferPointer()), out_blob->GetBufferSize()};
+    }
+  }
+
+#if 0  // Not much point in unloading the library, we'd need to keep "s_mutex_shader_compiler" locked the whole time.
+  FreeLibrary(d3d_compiler[library]);
+#endif
+
   return result;
 }
 
 inline HRESULT CreateLibrary(IDxcLibrary** dxc_library) {
+  const std::lock_guard<std::mutex> lock(s_mutex_shader_compiler);
   // HMODULE dxil_loader = LoadLibraryW(L"dxil.dll");
   HMODULE dx_compiler = LoadLibraryW(L"dxcompiler.dll");
   if (dx_compiler == nullptr) {
@@ -57,6 +70,7 @@ inline HRESULT CreateLibrary(IDxcLibrary** dxc_library) {
 }
 
 inline HRESULT CreateCompiler(IDxcCompiler** dxc_compiler) {
+  const std::lock_guard<std::mutex> lock(s_mutex_shader_compiler);
   // HMODULE dxil_loader = LoadLibraryW(L"dxil.dll");
   HMODULE dx_compiler = LoadLibraryW(L"dxcompiler.dll");
   if (dx_compiler == nullptr) {
@@ -97,49 +111,58 @@ inline std::optional<std::string> DisassembleShader(void* code, size_t size) {
   return result;
 }
 
-inline std::vector<uint8_t> CompileShaderFromFileFXC(LPCWSTR file_path, LPCSTR shader_target, LPCWSTR library = L"D3DCompiler_47.dll") {
+inline std::vector<uint8_t> CompileShaderFromFileFXC(LPCWSTR file_path, LPCSTR shader_target, const D3D_SHADER_MACRO* defines = nullptr, std::string* out_error = nullptr, LPCWSTR library = L"D3DCompiler_47.dll") {
+
+  typedef HRESULT(WINAPI * pD3DCompileFromFile)(LPCWSTR, const D3D_SHADER_MACRO*, ID3DInclude*, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob**, ID3DBlob**);
+  static std::unordered_map<LPCWSTR, pD3DCompileFromFile> d3d_compilefromfile;
+  {
+    const std::lock_guard<std::mutex> lock(s_mutex_shader_compiler);
+    static std::unordered_map<LPCWSTR, HMODULE> d3d_compiler;
+    d3d_compiler[library] = LoadLibraryW(library);
+    if (d3d_compiler[library] != nullptr) {
+      // NOLINTNEXTLINE(google-readability-casting)
+      d3d_compilefromfile[library] = pD3DCompileFromFile(GetProcAddress(d3d_compiler[library], "D3DCompileFromFile"));
+    }
+  }
+
   std::vector<uint8_t> result;
   CComPtr<ID3DBlob> out_blob;
-
-  HMODULE d3d_compiler = LoadLibraryW(library);
-  if (d3d_compiler != nullptr) {
-    typedef HRESULT(WINAPI * pD3DCompileFromFile)(
-        LPCWSTR, const D3D_SHADER_MACRO*, ID3DInclude*, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob**, ID3DBlob**);
-
-    // NOLINTNEXTLINE(google-readability-casting)
-    auto d3d_compilefromfile = pD3DCompileFromFile(GetProcAddress(d3d_compiler, "D3DCompileFromFile"));
-
-    if (d3d_compilefromfile != nullptr) {
-      CComPtr<ID3DBlob> error_blob;
-      if (SUCCEEDED(d3d_compilefromfile(
-              file_path,
-              nullptr,
-              D3D_COMPILE_STANDARD_FILE_INCLUDE,
-              "main",
-              shader_target,
-              D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY,
-              0,
-              &out_blob,
-              &error_blob))) {
-        result.assign(
-            reinterpret_cast<uint8_t*>(out_blob->GetBufferPointer()),
-            reinterpret_cast<uint8_t*>(out_blob->GetBufferPointer()) + out_blob->GetBufferSize());
-      } else {
-        std::stringstream s;
-        s << "CompileShaderFromFileFXC(Compilation failed";
-        if (error_blob != nullptr) {
-          // auto error_size = error_blob->GetBufferSize();
-          auto* error = reinterpret_cast<uint8_t*>(error_blob->GetBufferPointer());
-          s << ": " << error;
-        } else {
-          s << ".";
+  if (d3d_compilefromfile[library] != nullptr) {
+    CComPtr<ID3DBlob> error_blob;
+    if (SUCCEEDED(d3d_compilefromfile[library](
+            file_path,
+            defines,
+            D3D_COMPILE_STANDARD_FILE_INCLUDE,
+            "main",
+            shader_target,
+            D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY,
+            0,
+            &out_blob,
+            &error_blob))) {
+      result.assign(
+          reinterpret_cast<uint8_t*>(out_blob->GetBufferPointer()),
+          reinterpret_cast<uint8_t*>(out_blob->GetBufferPointer()) + out_blob->GetBufferSize());
+    } else {
+      std::stringstream s;
+      s << "CompileShaderFromFileFXC(Compilation failed";
+      if (error_blob != nullptr) {
+        // auto error_size = error_blob->GetBufferSize();
+        auto* error = reinterpret_cast<uint8_t*>(error_blob->GetBufferPointer());
+        s << ": " << error;
+        if (out_error != nullptr) {
+          out_error->assign((char*)error);
         }
-        s << ")";
-        reshade::log_message(reshade::log_level::error, s.str().c_str());
+      } else {
+        s << ".";
       }
+      s << ")";
+      reshade::log_message(reshade::log_level::error, s.str().c_str());
     }
-    FreeLibrary(d3d_compiler);
   }
+
+#if 0  // Not much point in unloading the library, we'd need to keep "s_mutex_shader_compiler" locked the whole time.
+  FreeLibrary(d3d_compiler[library]);
+#endif
 
   return result;
 }
@@ -190,7 +213,7 @@ inline HRESULT CompileFromBlob(
       CONST D3D_SHADER_MACRO* cursor = defines;
 
       // Convert to UTF-16.
-      while (cursor->Name != nullptr) {
+      while (cursor != nullptr && cursor->Name != nullptr) {
         define_values.emplace_back(CA2W(cursor->Name, CP_UTF8));
         if (cursor->Definition != nullptr) {
           define_values.emplace_back(
@@ -284,13 +307,13 @@ inline HRESULT WINAPI BridgeD3DCompileFromFile(
   CComPtr<IDxcLibrary> library;
   CComPtr<IDxcBlobEncoding> source;
   CComPtr<IDxcIncludeHandler> include_handler;
-  HRESULT hr;
 
   *code = nullptr;
   if (error_messages != nullptr) {
     *error_messages = nullptr;
   }
 
+  HRESULT hr;
   hr = CreateLibrary(&library);
   if (FAILED(hr)) return hr;
   hr = library->CreateBlobFromFile(file_name, nullptr, &source);
@@ -307,14 +330,14 @@ inline HRESULT WINAPI BridgeD3DCompileFromFile(
   return CompileFromBlob(source, file_name, defines, include_handler, entrypoint, target, flags1, flags2, code, error_messages);
 }
 
-inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR shader_target) {
+inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR shader_target, const D3D_SHADER_MACRO* defines = nullptr, std::string* out_error = nullptr) {
   std::vector<uint8_t> result;
 
   CComPtr<ID3DBlob> out_blob;
   CComPtr<ID3DBlob> error_blob;
   if (SUCCEEDED(BridgeD3DCompileFromFile(
           file_path,
-          nullptr,
+          defines,
           D3D_COMPILE_STANDARD_FILE_INCLUDE,
           "main",
           shader_target,
@@ -332,6 +355,9 @@ inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR s
       // auto error_size = error_blob->GetBufferSize();
       auto* error = reinterpret_cast<uint8_t*>(error_blob->GetBufferPointer());
       s << ": " << error;
+      if (out_error != nullptr) {
+        out_error->assign((char*)error);
+      }
     } else {
       s << ".";
     }
@@ -343,11 +369,21 @@ inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR s
   return result;
 }
 
-inline std::vector<uint8_t> CompileShaderFromFile(LPCWSTR file_path, LPCSTR shader_target, LPCWSTR library = L"D3DCompiler_47.dll") {
-  if (shader_target[3] < '6') {
-    return CompileShaderFromFileFXC(file_path, shader_target, library);
+inline std::vector<uint8_t> CompileShaderFromFile(LPCWSTR file_path, LPCSTR shader_target, const std::vector<std::string>& defines = {}, std::string* out_error = nullptr, LPCWSTR fxc_library = L"D3DCompiler_47.dll") {
+  std::vector<D3D_SHADER_MACRO> local_defines;
+  for (int i = 0; i < defines.size() && defines.size() > 1; i += 2) {
+    if (!defines[i].empty() && !defines[i + 1].empty()) {
+      local_defines.push_back({defines[i].c_str(), defines[i+1].c_str()});
+    }
   }
-  return CompileShaderFromFileDXC(file_path, shader_target);
+  if (local_defines.size() > 0) {
+    local_defines.push_back({nullptr, nullptr});
+  }
+
+  if (shader_target[3] < '6') {
+    return CompileShaderFromFileFXC(file_path, shader_target, local_defines.data(), out_error, fxc_library);
+  }
+  return CompileShaderFromFileDXC(file_path, shader_target, local_defines.data(), out_error);
 }
 
 }  // namespace renodx::utils::shader::compiler


### PR DESCRIPTION
* Fix live code tab not showing the shader code until you clicked on another shader

* Attempted fix for shader live hot reload creating two handles at once (this happened to me, shaders keep automatically loading after being changed even if I had turned live reload off)

* Show the name the user gave to a shader next to a pixel shader hash when tracing

* Fix memory leaks and possibly stale pointer/nullptr access crashes and also polish code `pipeline_cache_by_shader_hash` and `pipeline_cache_by_pipeline_handle` weren't handled 100% safely (they might still not be), though the situation should be better now. Some pipeline stuff was never deleted after being allocated with "new". I've also added some [[fallthrough]] on switch statements (some compiles don't compile without it), commented out batches of code with "#if ... #endif" instead of "// ...". This also adds the number of shader (cloned pipelines) that will be unloaded when clicking the "Unload" button, to highlight whether shaders were loaded or not.

* Makes newly created pipelines (from the game) be immediately replaced with our custom shaders if live reload is on (e.g. when the game uses a new shader for the first time, if that shader hash was present in our files and live reload is on, the custom shader will be immediately loaded and used instead)

* Force reloading "live code" shader string when shaders are reloaded (so you don't have to click on another shader and back on the one you were looking at)

* Improve trace custom shader names

* Automatically detect and append shader type (e.g. ps_5_0) to cso dumps

* Added shaders auto dump (all newly added shaders are dumped once in the first frame after creation)

* Add a compilation error string to the pipeline shader struct, and show it in the trace live view if the shader failed to compile. Shader passes in the trace now are also colored green if correctly replaced and red if their attempted custom shader failed to compile. This also fixes the shader name being printed in the trace.

* Forgotten shader compiler changes needed by previous CL

* Improve (and restore) live shader replacement (as in, automatically replacing any shader that is first used by the game with our custom one from the live folder). This is now optimized, it only tries to attempt to replace shaders that are actually in the user folder, any other shader will be ignored and won't cause a hitch. This also adds a bunch of security checks.

* Allow the "pipeline by shader hash" map to hold a pointer to more than one pipeline, because multiple pipelines can actually use the same shader (and thus shader hash) Previously it would simply replace the pipeline being pointed at by the map with the latest version, without acknowledging it.

* Little fix for commit before

* Move custom shader loading filtering to be done before shader compilation otherwise it still causes hitches

* Add Init() function and pre-cache all the already dumped shaders by hash there, so we don't dump them again with auto dumping, which would cause stutters every time you boot the game

* Fix trace disassembly tab shader text not re-loading if you change shader selection while looking at the live view (and not the disassembly view)

* Add assert for shaders that ended up having the same hash, to make sure they also had the same size (just an extra safety measure)

* Fix crash on trace view

* Reset compilation error when unloading shaders

* Add shader compiler defines to quickly iterate on changes and check for diffs without having to alt tab to the shader editor every time

* Add a button to test shaders by forcing them to fail drawing (and thus draw nothing/black)

* Track traces indices by pipeline and not by shader (the button to filter out duplicate shaders is still working) The previous code didn't allow per pipeline parameters as it was assuming that a single pipeline matched a single shader and viceversa

* Fix "unload shaders" button not disabling test on all shaders

* Reset trace shader selection index when tracing again

* Add support for vertex shaders trace and dump (I think loading was already supported, not sure, it is now)

* Allow pipelines to define more than one shader hash (might not be necessary, but it seems to make the flow better). Fixed some further memory leaks.
Improved vertex shader filtering for traces, and color vertex shaders in yellow in the trace list.

* Fixed last commit breaking auto shader loading

* Avoid trying to auto load state pipelines

* Fixed live reloading accidentally loading more shaders than it needed to (it should only replace shaders for a single pipeline)

* Increase shader defines from 3 to 4

* Threading refactor: -Made everything 100% thread safe (some stuff was seemengly still unsafe even before my changes) -Made a new struct and array to hold the custom user shader shaders compiled data (e.g. compiled binary, path, compilation error). Previously this stuff was stored all over the place -Split up custom shader loading from custom shader compiling into two functions -Made auto shader dumping async so it doesn't hitch performance -Made auto shader loading optionally async so it doesn't hitch performance, but anyway moved all shader compilation to the beginning (on startup) and also made it async, so shaders are pre-build and can be live replaced on the spot when they first appear -Given that auto dumping and auto loading don't cause stutters anymore, they are now on by default -Split up auto loading from live reloading (the first automatically applies custom user shaders on shaders that the game first loaded at arbitrary points, the second re-loads the custom user shaders every time their hlsl is changed) -Added a lot more comments around to clarify the code -Fixed cso that has .ps_x_x appendxi not loading anymore

* Fix potential crashes

* Make the shader compiler thread safe and avoid it unloading the DX compiler DLL once it's done using it, it doesn't make much sense to load it and unload it every time shaders are compiled.