### PR TITLE
[SMT5] Hide unused sliders

### DIFF
--- a/src/games/smt5/addon.cpp
+++ b/src/games/smt5/addon.cpp
@@ -108,6 +108,7 @@ renodx::utils::settings::Settings settings = {
         .section = "Tone Mapping",
         .tooltip = "Sets the tone mapper type",
         .labels = {"Vanilla", "None", "ACES"},
+        .is_enabled = []() { return shader_injection.toneMapType != 2; },
     },
 
     new renodx::utils::settings::Setting{
@@ -187,16 +188,16 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.02f; },
     },
 
-    new renodx::utils::settings::Setting{
-        .key = "colorGradeBlowout",
-        .binding = &shader_injection.colorGradeBlowout,
-        .default_value = 50.f,
-        .label = "Blowout",
-        .section = "Color Grading",
-        .tooltip = "Controls highlight desaturation due to overexposure.",
-        .max = 100.f,
-        .parse = [](float value) { return value * 0.01f; },
-    },
+    //new renodx::utils::settings::Setting{
+    //    .key = "colorGradeBlowout",
+    //    .binding = &shader_injection.colorGradeBlowout,
+    //    .default_value = 50.f,
+    //    .label = "Blowout",
+    //    .section = "Color Grading",
+    //    .tooltip = "Controls highlight desaturation due to overexposure.",
+    //    .max = 100.f,
+    //    .parse = [](float value) { return value * 0.01f; },
+    //},
 
     //new renodx::utils::settings::Setting{
     //    .key = "toneMapHueCorrection",
@@ -238,7 +239,7 @@ void OnPresetOff() {
   renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
   renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
   renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
-  renodx::utils::settings::UpdateSetting("colorGradeBlowout", 50.f);
+  //renodx::utils::settings::UpdateSetting("colorGradeBlowout", 50.f);
   //renodx::utils::settings::UpdateSetting("toneMapHueCorrection", 50.f);
 }
 


### PR DESCRIPTION
- Disable tonemap type, since ACES is the only one that works anyway

- Remove blowout, since its not configured (hardcoded to the ideal value)