### PR TITLE
[YS10] Upgrade RGBA8_Unorm render targets

### DIFF
--- a/src/games/ys10/addon.cpp
+++ b/src/games/ys10/addon.cpp
@@ -183,11 +183,19 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       renodx::mods::swapchain::force_borderless = false;     // needed for stability
       renodx::mods::swapchain::prevent_full_screen = false;  // needed for stability
 
-      // RGBA8_typeless
-      //   renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
-      //       .old_format = reshade::api::format::r8g8b8a8_typeless,
-      //       .new_format = reshade::api::format::r16g16b16a16_float,
-      //   });
+      // RGBA8_UNORM 16:9
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .aspect_ratio = 16.f / 9.f,
+      });
+
+      // RGBA8_UNORM 512x512
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .dimensions = {512,512},
+      });
 
       // R11G11B10
       // renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({.old_format = reshade::api::format::r11g11b10_float,


### PR DESCRIPTION
- Upgrade RGBA8U RTs that are either 16L9 or 512x512

- Might reduce banding or add some particle effects to the UI