### PR TITLE
[mod:ue-extended] Add Densha Attack post-processing shaders

### DIFF
--- a/src/games/ue-extended/games/denshattack/color_vignette_0x2AEEA61C.ps_5_x.hlsl
+++ b/src/games/ue-extended/games/denshattack/color_vignette_0x2AEEA61C.ps_5_x.hlsl
@@ -1,0 +1,142 @@
+#include "../postfx.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Fri Jul 17 03:09:38 2026
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[3];
+}
+
+cbuffer cb1 : register(b1)
+{
+  float4 cb1[164];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[11];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = asuint(cb0[10].xy);
+  r0.xy = v0.xy + -r0.xy;
+  r1.xyzw = -r0.xyxy * cb0[10].zwzw + float4(0.5,0.5,0.5,0.5);
+  r1.xyzw = cb2[0].xxxx * r1.xyzw;
+  r0.zw = cb0[10].zw * r0.xy;
+  r0.xy = r0.xy * cb0[10].zw + float2(-0.5,-0.5);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = sqrt(r0.x);
+  r2.xyzw = saturate(r1.zwzw * float4(-0.0799999982,-0.0799999982,-0.0500000007,-0.0500000007) + r0.zwzw);
+  r2.xyzw = r2.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r3.xyz = t0.Sample(s0_s, r2.zw).xyz;
+  r2.xyzw = t0.Sample(s0_s, r2.xy).xyzw;
+
+  r3.xyz = InvertLUTEncode(r3.xyz);
+  r2.xyz = InvertLUTEncode(r2.xyz);
+
+  r2.xyz = r2.xyz + r3.xyz;
+  o0.w = r2.w;
+  r3.xyzw = saturate(r1.zwzw * float4(-0.0299999993,-0.0299999993,-0.0199999996,-0.0199999996) + r0.zwzw);
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyzw = saturate(r1.zwzw * float4(-0.00999999978,-0.00999999978,0.00999999978,0.00999999978) + r0.zwzw);
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r4.xy = saturate(r0.zw);
+  r4.xy = r4.xy * cb0[0].zw + cb0[0].xy;
+  r4.xyz = t0.Sample(s0_s, r4.xy).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyzw = saturate(r1.zwzw * float4(0.0199999996,0.0199999996,0.0299999993,0.0299999993) + r0.zwzw);
+  r1.xyzw = saturate(r1.xyzw * float4(0.0500000007,0.0500000007,0.0799999982,0.0799999982) + r0.zwzw);
+  r0.yz = r0.zw * cb0[0].zw + cb0[0].xy;
+  r0.yz = max(cb0[1].xy, r0.yz);
+  r0.yz = min(cb0[1].zw, r0.yz);
+  r0.yzw = t0.Sample(s0_s, r0.yz).xyz;
+
+  r0.yzw = InvertLUTEncode(r0.yzw);
+
+  r1.xyzw = r1.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyz = t0.Sample(s0_s, r1.xy).xyz;
+  r1.xyz = t0.Sample(s0_s, r1.zw).xyz;
+
+  r3.xyz = InvertLUTEncode(r3.xyz);
+  r1.xyz = InvertLUTEncode(r1.xyz);
+
+  r2.xyz = r3.xyz + r2.xyz;
+  r1.xyz = r2.xyz + r1.xyz;
+  r1.xyz = cb2[0].yzw * r1.xyz;
+  r2.xyz = float3(0.0909090936,0.0909090936,0.0909090936) * r1.xyz;
+  r1.xyz = -r1.xyz * float3(0.0909090936,0.0909090936,0.0909090936) + r0.yzw;
+  r1.xyz = r1.xyz * float3(0.5,0.5,0.5) + r2.xyz;
+  r1.w = dot(r0.yzw, float3(0.212639004,0.715168655,0.0721923187));
+  r2.xyz = r1.www + -r0.yzw;
+  r0.yzw = cb2[1].xxx * r2.xyz + r0.yzw;
+  r0.yzw = r0.yzw + -r1.xyz;
+  r1.w = 25.1327419 * cb1[163].z;
+  r1.w = sin(r1.w);
+  r1.w = 1 + r1.w;
+  r1.w = r1.w * -0.100000016 + 1.10000002;
+  r1.w = cb2[1].y * r1.w;
+  r0.x = r0.x / r1.w;
+  r0.x = 1 + -r0.x;
+  r1.w = cb2[1].z * r0.x;
+  r1.w = r1.w * r1.w;
+  r1.w = 1.44269514 * r1.w;
+  r1.w = exp2(r1.w);
+  r1.w = 1 / r1.w;
+  r1.w = 1 + -r1.w;
+  r2.x = cmp(r0.x >= 0);
+  r0.x = cmp(9.99999975e-06 < abs(r0.x));
+  r1.w = r2.x ? r1.w : 0;
+  r0.x = r0.x ? r1.w : 0;
+  r0.xyz = r0.xxx * r0.yzw + r1.xyz;
+  r1.xyz = cb2[2].xyz + -r0.xyz;
+  r0.xyz = cb2[1].www * r1.xyz + r0.xyz;
+
+  r0.xyz = renodx::math::Select(RENODX_TONE_MAP_TYPE == 0, max(0, r0.xyz), r0.xyz);
+  o0.xyz = ApplyLUTEncode(r0.xyz);
+  return;
+}

--- a/src/games/ue-extended/games/denshattack/speedlines_0x42DC8473.ps_5_x.hlsl
+++ b/src/games/ue-extended/games/denshattack/speedlines_0x42DC8473.ps_5_x.hlsl
@@ -1,0 +1,126 @@
+#include "../postfx.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Fri Jul 17 03:09:38 2026
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb1 : register(b1)
+{
+  float4 cb1[2];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[11];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = asuint(cb0[10].xy);
+  r0.xy = v0.xy + -r0.xy;
+  r1.xyzw = -r0.xyxy * cb0[10].zwzw + float4(0.5,0.5,0.5,0.5);
+  r1.xyzw = cb1[0].xxxx * r1.xyzw;
+  r0.zw = cb0[10].zw * r0.xy;
+  r0.xy = r0.xy * cb0[10].zw + float2(-0.5,-0.5);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = sqrt(r0.x);
+  r0.x = -r0.x * cb1[0].y + 1;
+  r2.xyzw = saturate(r1.zwzw * float4(-0.0799999982,-0.0799999982,-0.0500000007,-0.0500000007) + r0.zwzw);
+  r2.xyzw = r2.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r3.xyz = t0.Sample(s0_s, r2.zw).xyz;
+  r2.xyzw = t0.Sample(s0_s, r2.xy).xyzw;
+
+  r3.xyz = InvertLUTEncode(r3.xyz);
+  r2.xyz = InvertLUTEncode(r2.xyz);
+
+  r2.xyz = r2.xyz + r3.xyz;
+  o0.w = r2.w;
+  r3.xyzw = saturate(r1.zwzw * float4(-0.0299999993,-0.0299999993,-0.0199999996,-0.0199999996) + r0.zwzw);
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyzw = saturate(r1.zwzw * float4(-0.00999999978,-0.00999999978,0.00999999978,0.00999999978) + r0.zwzw);
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r4.xy = saturate(r0.zw);
+  r4.xy = r4.xy * cb0[0].zw + cb0[0].xy;
+  r4.xyz = t0.Sample(s0_s, r4.xy).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyzw = saturate(r1.zwzw * float4(0.0199999996,0.0199999996,0.0299999993,0.0299999993) + r0.zwzw);
+  r1.xyzw = saturate(r1.xyzw * float4(0.0500000007,0.0500000007,0.0799999982,0.0799999982) + r0.zwzw);
+  r0.yz = r0.zw * cb0[0].zw + cb0[0].xy;
+  r0.yz = max(cb0[1].xy, r0.yz);
+  r0.yz = min(cb0[1].zw, r0.yz);
+  r0.yzw = t0.Sample(s0_s, r0.yz).xyz;
+
+  r0.yzw = InvertLUTEncode(r0.yzw);
+
+  r1.xyzw = r1.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r3.xyzw = r3.xyzw * cb0[0].zwzw + cb0[0].xyxy;
+  r4.xyz = t0.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t0.Sample(s0_s, r3.zw).xyz;
+
+  r4.xyz = InvertLUTEncode(r4.xyz);
+  r3.xyz = InvertLUTEncode(r3.xyz);
+
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r3.xyz = t0.Sample(s0_s, r1.xy).xyz;
+  r1.xyz = t0.Sample(s0_s, r1.zw).xyz;
+
+  r3.xyz = InvertLUTEncode(r3.xyz);
+  r1.xyz = InvertLUTEncode(r1.xyz);
+
+  r2.xyz = r3.xyz + r2.xyz;
+  r1.xyz = r2.xyz + r1.xyz;
+  r0.yzw = -r1.xyz * float3(0.0909090936,0.0909090936,0.0909090936) + r0.yzw;
+  r1.w = cb1[0].z * r0.x;
+  r1.w = r1.w * r1.w;
+  r1.xyzw = float4(0.0909090936,0.0909090936,0.0909090936,1.44269514) * r1.xyzw;
+  r1.w = exp2(r1.w);
+  r1.w = 1 / r1.w;
+  r1.w = 1 + -r1.w;
+  r2.x = cmp(r0.x >= 0);
+  r0.x = cmp(9.99999975e-06 < abs(r0.x));
+  r1.w = r2.x ? r1.w : 0;
+  r0.x = r0.x ? r1.w : 0;
+  r0.xyz = r0.xxx * r0.yzw + r1.xyz;
+  r1.xyz = cb1[1].xyz + -r0.xyz;
+  r0.xyz = cb1[0].www * r1.xyz + r0.xyz;
+
+  r0.xyz = renodx::math::Select(RENODX_TONE_MAP_TYPE == 0, max(0, r0.xyz), r0.xyz);
+  o0.xyz = ApplyLUTEncode(r0.xyz);
+
+  //o0.xyz = 0;
+  return;
+}

--- a/src/games/ue-extended/games/denshattack/unknown_0x373683FC.ps_5_x.hlsl
+++ b/src/games/ue-extended/games/denshattack/unknown_0x373683FC.ps_5_x.hlsl
@@ -1,0 +1,106 @@
+#include "../postfx.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Fri Jul 17 03:09:38 2026
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb3 : register(b3)
+{
+  float4 cb3[5];
+}
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[1];
+}
+
+cbuffer cb1 : register(b1)
+{
+  float4 cb1[164];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[6];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = asuint(cb0[5].xy);
+  r0.xy = v0.xy + -r0.xy;
+  r0.zw = r0.xy * cb0[5].zw + float2(-0.5,-0.5);
+  r0.xy = cb0[5].zw * r0.xy;
+  r0.z = dot(r0.zw, r0.zw);
+  r0.z = sqrt(r0.z);
+  r0.z = -r0.z * cb3[1].z + 1;
+  r0.w = cb3[1].w * r0.z;
+  r0.w = r0.w * r0.w;
+  r0.w = 1.44269514 * r0.w;
+  r0.w = exp2(r0.w);
+  r0.w = 1 / r0.w;
+  r0.w = 1 + -r0.w;
+  r1.x = cmp(r0.z >= 0);
+  r0.z = cmp(9.99999975e-06 < abs(r0.z));
+  r0.w = r1.x ? r0.w : 0;
+  r0.z = r0.z ? r0.w : 0;
+  r0.w = cb3[0].x * cb1[163].z;
+  r0.w = 6.28318548 * r0.w;
+  r0.w = sin(r0.w);
+  r0.w = 1 + r0.w;
+  r1.xy = cmp(r0.ww >= float2(1.20000005,0.600000024));
+  r1.zw = r0.xy * cb3[0].yz + cb3[1].xy;
+  r0.xy = r0.xy * cb0[0].zw + cb0[0].xy;
+  r2.xyzw = t3.Sample(s3_s, r0.xy).xyzw;
+
+  r2.xyz = InvertLUTEncode(r2.xyz);
+
+  r0.x = t0.Sample(s0_s, r1.zw).w;
+  r0.y = t1.Sample(s1_s, r1.zw).w;
+  r0.w = t2.Sample(s2_s, r1.zw).w;
+  r0.x = r1.x ? r0.x : r0.y;
+  r0.x = r1.y ? r0.x : r0.w;
+  r0.x = r0.z * -r0.x + r0.x;
+  r0.y = -cb3[2].y + cb2[0].y;
+  r0.y = cb3[2].x * r0.y + cb3[2].y;
+  r0.x = r0.x * r0.y;
+  r0.x = max(0, r0.x);
+  r0.x = min(cb3[2].z, r0.x);
+  r0.yzw = cb3[3].xyz + -r2.xyz;
+  r0.xyz = r0.xxx * r0.yzw + r2.xyz;
+  o0.w = r2.w;
+  r1.xyz = cb3[4].xyz + -r0.xyz;
+  r0.xyz = cb3[3].www * r1.xyz + r0.xyz;
+
+  r0.xyz = renodx::math::Select(RENODX_TONE_MAP_TYPE == 0, max(0, r0.xyz), r0.xyz);
+  o0.xyz = ApplyLUTEncode(r0.xyz);
+
+  //o0.xyz = 0;
+  return;
+}

--- a/src/games/ue-extended/games/postfx.hlsli
+++ b/src/games/ue-extended/games/postfx.hlsli
@@ -160,3 +160,29 @@ float3 ConvertSRGBtoPQAndUpgradeToneMap(float3 srgb_color,
       renodx::color::bt2020::from::BT709(tonemapped_linear),
       RENODX_DIFFUSE_WHITE_NITS);
 }
+
+// Convert the current processing path to unscaled sRGB-encoded BT.709.
+float3 InvertLUTEncode(float3 color) {
+  if (PROCESSING_PATH == 0.f) return ConvertPQToSRGB(color);
+
+  if (RENODX_DIFFUSE_WHITE_NITS != RENODX_GRAPHICS_WHITE_NITS) {
+    color = renodx::color::gamma::DecodeSafe(color);
+    color /= (RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS);
+    color = renodx::color::gamma::EncodeSafe(color);
+  }
+
+  return color;
+}
+
+// Convert sRGB-encoded BT.709 to the scaled current processing path.
+float3 ApplyLUTEncode(float3 color) {
+  if (PROCESSING_PATH == 0.f) return ConvertSRGBtoPQ(color);
+
+  if (RENODX_DIFFUSE_WHITE_NITS != RENODX_GRAPHICS_WHITE_NITS) {
+    color = renodx::color::gamma::DecodeSafe(color);
+    color *= (RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS);
+    color = renodx::color::gamma::EncodeSafe(color);
+  }
+
+  return color;
+}


### PR DESCRIPTION
## Summary
- Add Densha Attack post-processing shader overrides for color vignette, speedlines, and an additional post-effect pass.
- Add shared LUT encode/decode helpers in `postfx.hlsli` for the current processing path.
- Preserve the existing Vanilla/0 behavior while routing custom tone-map output through the shared processing path.

## Verification
- Confirmed the four intended files are committed and the working tree is clean.
- Shader/runtime verification remains for game-side testing.

## RenoDX review checklist
- PR scope and commits are tidy: Pass
- Defaults preserve the original/vanilla look: Needs runtime verification
- Preset Off/reset and Vanilla/0 behavior are clear: Pass
- No final-frame inverse tonemapping: Pass
- Tonemap/LUT signal and domain handling: Needs runtime verification
- Output mode and swapchain handling: N/A