### PR TITLE
[UE-EXTENDED] Refactor LUT builder color processing

### DIFF
--- a/src/games/ue-extended/addon.cpp
+++ b/src/games/ue-extended/addon.cpp
@@ -118,6 +118,19 @@ renodx::utils::settings::Settings settings = {
         .tooltip = "Emulates a 2.2 EOTF",
         .labels = {"Off", "2.2"},
     },
+      new renodx::utils::settings::Setting{
+        .key = "ToneMapGammaCorrectionWorkingSpace",
+        .binding = &shader_injection.gamma_correction_working_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "SDR EOTF Scaling",
+        .section = "Tone Mapping",
+        .tooltip = "Display Emulation: Matches the behavior of the display in SDR\n"
+               "Match Tone Map Scaling: Performs the correction in the working space of the selected tone map scaling. May have a preferrable look.",
+        .labels = {"Display Emulation", "Match Tone Map Scaling"},
+        .is_enabled = []() { return shader_injection.gamma_correction != 0.f; },
+        .is_visible = []() { return current_settings_mode >= 2.f; },
+      },
 
     new renodx::utils::settings::Setting{
         .key = "BlendFactor",
@@ -239,6 +252,19 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
+
+    // new renodx::utils::settings::Setting{
+    //     .key = "ToneMapHueBlowoutWorkingSpace",
+    //     .binding = &shader_injection.tone_map_hue_blowout_working_space,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Hue/Blowout Working Space",
+    //     .section = "Scene Grading",
+    //     .tooltip = "Selects the perceptual working space used by the Max Channel hue-shift and blowout controls.",
+    //     .labels = {"OKLab", "ICtCp"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type == 1.f && shader_injection.tone_map_scaling == 0.f; },
+    //     .is_visible = []() { return current_settings_mode >= 1.f; },
+    // },
 
     new renodx::utils::settings::Setting{
         .key = "OverrideBlackClip",
@@ -406,6 +432,18 @@ renodx::utils::settings::Settings settings = {
         .is_enabled = []() { return shader_injection.tone_map_type != 0; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
+    // new renodx::utils::settings::Setting{
+    //     .key = "ColorGradeLUTGamutCompressionDebug",
+    //     .binding = &shader_injection.custom_lut_gamut_compression_method,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 1.f,
+    //     .label = "LUT Gamut Compression Debug",
+    //     .section = "Color Grading LUTs",
+    //     .tooltip = "Compares the legacy gamma-domain LUT gamut compression against the adaptive-D65 replacement.",
+    //     .labels = {"Legacy Gamma", "Adaptive D65"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type != 0 && shader_injection.custom_lut_gamut_restoration != 0.f; },
+    //     .is_visible = []() { return current_settings_mode >= 2.f; },
+    // },
     // new renodx::utils::settings::Setting{
     //     .key = "FixPostProcess",
     //     .binding = &shader_injection.fix_post_process,

--- a/src/games/ue-extended/common.hlsli
+++ b/src/games/ue-extended/common.hlsli
@@ -1,2 +1,91 @@
+#ifndef SRC_GAMES_UE_EXTENDED_COMMON_HLSLI_
+#define SRC_GAMES_UE_EXTENDED_COMMON_HLSLI_
+
 #include "./shared.h"
+
+#define RENODX_BT709_LMS_WHITE renodx::color::lms::from::BT709(1.f.xxx)
+
+float3 ApplyBlueCorrectionPre(float3 untonemapped_ap1, float blue_correction) {
+	if (FORCE_BLUE_CORRECT == 1.f) {
+		blue_correction = 0.6f;
+	}
+
+	float r = untonemapped_ap1.r, g = untonemapped_ap1.g, b = untonemapped_ap1.b;
+
+	float corrected_r = ((mad(0.061360642313957214f, b, mad(-4.540197551250458e-09f, g, (r * 0.9386394023895264f))) - r) * blue_correction) + r;
+	float corrected_g = ((mad(0.169205904006958f, b, mad(0.8307942152023315f, g, (r * 6.775371730327606e-08f))) - g) * blue_correction) + g;
+	float corrected_b = (mad(-2.3283064365386963e-10f, g, (r * -9.313225746154785e-10f)) * blue_correction) + b;
+
+	return float3(corrected_r, corrected_g, corrected_b);
+}
+
+float3 ApplyBlueCorrectionPost(float3 tonemapped_ap1, float blue_correction) {
+	if (FORCE_BLUE_CORRECT == 1.f) {
+		blue_correction = 0.6f;
+	}
+
+	float r = tonemapped_ap1.r, g = tonemapped_ap1.g, b = tonemapped_ap1.b;
+
+	float corrected_r = ((mad(-0.06537103652954102f, b, mad(1.451815478503704e-06f, g, (r * 1.065374732017517f))) - r) * blue_correction) + r;
+	float corrected_g = ((mad(-0.20366770029067993f, b, mad(1.2036634683609009f, g, (r * -2.57161445915699e-07f))) - g) * blue_correction) + g;
+	float corrected_b = ((mad(0.9999996423721313f, b, mad(2.0954757928848267e-08f, g, (r * 1.862645149230957e-08f))) - b) * blue_correction) + b;
+
+	return float3(corrected_r, corrected_g, corrected_b);
+}
+
+float3 BlueCorrectedAP1FromBT709(float3 color_bt709, float blue_correction) {
+	return ApplyBlueCorrectionPre(
+			renodx::color::ap1::from::BT709(color_bt709),
+			blue_correction);
+}
+
+float3 BT709FromBlueCorrectedAP1(float3 color_ap1, float blue_correction) {
+	return renodx::color::bt709::from::AP1(
+			ApplyBlueCorrectionPost(color_ap1, blue_correction));
+}
+
+float3 BlueCorrectedAP1FromLMS(float3 color_lms, float blue_correction) {
+	return ApplyBlueCorrectionPre(
+			renodx::color::ap1::from::LMS(color_lms),
+			blue_correction);
+}
+
+float3 LMSFromBlueCorrectedAP1(float3 color_ap1, float blue_correction) {
+	return renodx::color::lms::from::AP1(
+			ApplyBlueCorrectionPost(color_ap1, blue_correction));
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 ApplyGammaCorrectionAP1(float3 color_bt709, bool inverse, float blue_correction) {
+	float3 color_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(color_bt709, blue_correction);
+	return BT709FromBlueCorrectedAP1(
+			renodx::color::correct::GammaSafe(color_blue_corrected_ap1, inverse),
+			blue_correction);
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 ApplyGammaCorrectionLMS(float3 color_bt709, bool inverse) {
+	float3 color_lms_normalized = renodx::color::lms::from::BT709(color_bt709) / RENODX_BT709_LMS_WHITE;
+	return renodx::color::bt709::from::LMS(
+			renodx::color::correct::GammaSafe(color_lms_normalized, inverse) * RENODX_BT709_LMS_WHITE);
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 ApplyGammaCorrection(float3 color_bt709, bool inverse = false, float blue_correction = 0.f) {
+	if (RENODX_GAMMA_CORRECTION == 0.f) return color_bt709;
+
+	if (RENODX_GAMMA_CORRECTION_WORKING_SPACE == 0.f || RENODX_TONE_MAP_TYPE == 0.f) {
+		return renodx::color::correct::GammaSafe(color_bt709, inverse);
+	}
+
+	if (RENODX_TONE_MAP_SCALING <= 1.f) {
+		return ApplyGammaCorrectionAP1(color_bt709, inverse, blue_correction);
+	}
+	return ApplyGammaCorrectionLMS(color_bt709, inverse);
+}
+
+#endif  // SRC_GAMES_UE_EXTENDED_COMMON_HLSLI_
 

--- a/src/games/ue-extended/lutbuilder/filmiclutbuilder.hlsli
+++ b/src/games/ue-extended/lutbuilder/filmiclutbuilder.hlsli
@@ -83,59 +83,123 @@ float3 ApplyACESRRTAndODT(float3 untonemapped_ap1) {
   return tonemapped_ap1;
 }
 
-float3 ApplyPostToneMapDesaturation(float3 tonemapped) {
-  float grayscale = renodx::color::y::from::AP1(tonemapped);
-  return max(0.f, lerp(grayscale, tonemapped, 0.93f));
+// input: blue-corrected AP1 linear
+// output: blue-corrected AP1 linear
+float3 ApplyPostToneMapDesaturation(float3 tonemapped_blue_corrected_ap1) {
+  float grayscale = renodx::color::y::from::AP1(tonemapped_blue_corrected_ap1);
+  return max(0.f, lerp(grayscale, tonemapped_blue_corrected_ap1, 0.93f));
 }
 
-float3 LerpToneMapStrength(float3 tonemapped, float3 preRRT, UECbufferConfig cb_config) {
-  preRRT = min(100.f, preRRT);  // prevents artifacts during night vision in Robocop
-  return lerp(preRRT, tonemapped, saturate(cb_config.ue_tonecurveammount));
+// input: white-normalized LMS linear
+// output: white-normalized LMS linear
+float3 ApplyPostToneMapDesaturationLMS(float3 tonemapped_lms_normalized) {
+  float y_white = renodx::color::xyz::from::LMS(RENODX_BT709_LMS_WHITE).y;
+  float y = renodx::color::xyz::from::LMS(
+      tonemapped_lms_normalized * RENODX_BT709_LMS_WHITE).y;
+  float grayscale = renodx::math::DivideSafe(y, y_white, 0.f);
+  return max(0.f, lerp(grayscale, tonemapped_lms_normalized, 0.93f));
 }
 
-void ApplyFilmToneMapWithBlueCorrect(float3 untonemapped,
-                                     inout float3 tonemapped, UECbufferConfig cb_config) {
-  float3 untonemapped_ap1 = untonemapped;
+// input/output: same linear working space
+float3 LerpToneMapStrength(float3 tonemapped, float3 pre_tonemap, UECbufferConfig cb_config) {
+  pre_tonemap = min(100.f, pre_tonemap);  // prevents artifacts during night vision in Robocop
+  return lerp(pre_tonemap, tonemapped, saturate(cb_config.ue_tonecurveammount));
+}
+
+// input: AP1 linear
+// output: blue-corrected AP1 linear
+float3 PrepareFilmicInputMaxChannelPath(float3 untonemapped_ap1, UECbufferConfig cb_config) {
   renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  return ApplyBlueCorrectionPre(
+      ApplyExposureContrastFlareHighlightsShadowsByLuminance(untonemapped_ap1, cg_config, 0.18f),
+      cb_config.ue_bluecorrection);
+}
 
-  float3 untonemapped_prebluecorrect_ap1 = ApplyBlueCorrectionPre(untonemapped_ap1, cb_config.ue_bluecorrection);
+// input: AP1 linear
+// output: blue-corrected AP1 linear
+float3 PrepareFilmicInputAP1Path(float3 untonemapped_ap1, UECbufferConfig cb_config) {
+  renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  return ApplyAnchoredContrast(
+      ApplyBlueCorrectionPre(
+      untonemapped_ap1,
+          cb_config.ue_bluecorrection)
+          * cg_config.exposure,
+      cg_config);
+}
 
-  if (RENODX_TONE_MAP_TYPE != 0.f) {
-    if (RENODX_TONE_MAP_SCALING == 0.f) {
-      untonemapped_prebluecorrect_ap1 = ApplyBlueCorrectionPre(
-          ApplyExposureContrastFlareHighlightsShadowsByLuminance(untonemapped_ap1, cg_config, 0.18f),
-          cb_config.ue_bluecorrection);
-    } else {
-      untonemapped_prebluecorrect_ap1 = ApplyAnchoredContrast(untonemapped_prebluecorrect_ap1 * cg_config.exposure, cg_config);
-    }
+// input: AP1 linear
+// output: white-normalized LMS linear
+float3 PrepareFilmicInputLMSPath(float3 untonemapped_ap1) {
+  renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  float3 untonemapped_lms_normalized =
+      renodx::color::lms::from::AP1(untonemapped_ap1) / RENODX_BT709_LMS_WHITE;
+  return ApplyAnchoredContrast(
+      untonemapped_lms_normalized * cg_config.exposure,
+      cg_config);
+}
+
+// input: AP1 linear
+// output: AP1 linear
+void ApplyFilmicToneMap(
+    float3 untonemapped_ap1,
+    inout float3 tonemapped_ap1,
+    UECbufferConfig cb_config) {
+  if (RENODX_TONE_MAP_TYPE == 1.f && RENODX_TONE_MAP_SCALING == 2.f) {
+    float3 untonemapped_lms_normalized = PrepareFilmicInputLMSPath(untonemapped_ap1);
+    float filmic_black_clip = cb_config.ue_filmblackclip;
+    if (OVERRIDE_BLACK_CLIP) filmic_black_clip = 0.f;
+    unrealengine::filmtonemap::Config filmic_params =
+        unrealengine::filmtonemap::config::Create(
+            cb_config.ue_filmslope,
+            cb_config.ue_filmtoe,
+            cb_config.ue_filmshoulder,
+            filmic_black_clip,
+            cb_config.ue_filmwhiteclip);
+    float3 tonemapped_lms_normalized = ApplyExtendedToneCurveLMS(
+        untonemapped_lms_normalized,
+        filmic_params);
+    tonemapped_lms_normalized = ApplyPostToneMapDesaturationLMS(
+        tonemapped_lms_normalized);
+    tonemapped_lms_normalized = LerpToneMapStrength(
+        tonemapped_lms_normalized,
+        untonemapped_lms_normalized,
+        cb_config);
+    tonemapped_ap1 = renodx::color::ap1::from::LMS(
+        max(0.f, tonemapped_lms_normalized) * RENODX_BT709_LMS_WHITE);
+    return;
   }
 
-  float3 tonemapped_ap1;
+  float3 untonemapped_blue_corrected_ap1;
+  if (RENODX_TONE_MAP_TYPE == 0.f) {
+    untonemapped_blue_corrected_ap1 = ApplyBlueCorrectionPre(untonemapped_ap1, cb_config.ue_bluecorrection);
+  } else if (RENODX_TONE_MAP_SCALING == 0.f) {
+    untonemapped_blue_corrected_ap1 = PrepareFilmicInputMaxChannelPath(untonemapped_ap1, cb_config);
+  } else {
+    untonemapped_blue_corrected_ap1 = PrepareFilmicInputAP1Path(untonemapped_ap1, cb_config);
+  }
 
   // Vanilla+ and UE Filmic
-  float3 untonemapped_rrt_prebluecorrect_ap1 = renodx::tonemap::aces::RRT(
-      mul(renodx::color::AP1_TO_AP0_MAT, untonemapped_prebluecorrect_ap1));
+  float3 untonemapped_rrt_blue_corrected_ap1 = renodx::tonemap::aces::RRT(
+      mul(renodx::color::AP1_TO_AP0_MAT, untonemapped_blue_corrected_ap1));
 
-  float3 tonemapped_prebluecorrect_ap1;
+  float3 tonemapped_blue_corrected_ap1;
   if (RENODX_TONE_MAP_TYPE == 0.f) {  // Vanilla
-    tonemapped_prebluecorrect_ap1 =
-        unrealengine::filmtonemap::ApplyToneCurve(untonemapped_rrt_prebluecorrect_ap1, cb_config.ue_filmslope, cb_config.ue_filmtoe, cb_config.ue_filmshoulder, cb_config.ue_filmblackclip, cb_config.ue_filmwhiteclip);
+    tonemapped_blue_corrected_ap1 =
+        unrealengine::filmtonemap::ApplyToneCurve(untonemapped_rrt_blue_corrected_ap1, cb_config.ue_filmslope, cb_config.ue_filmtoe, cb_config.ue_filmshoulder, cb_config.ue_filmblackclip, cb_config.ue_filmwhiteclip);
   } else if (RENODX_TONE_MAP_TYPE == 1.f) {
-    tonemapped_prebluecorrect_ap1 =
-        ApplyToneCurveExtendedWithHermite(untonemapped_rrt_prebluecorrect_ap1, untonemapped_prebluecorrect_ap1, cb_config.ue_filmslope, cb_config.ue_filmtoe, cb_config.ue_filmshoulder, cb_config.ue_filmblackclip, cb_config.ue_filmwhiteclip);
+    tonemapped_blue_corrected_ap1 =
+      ApplyToneCurveExtendedWithHermite(untonemapped_rrt_blue_corrected_ap1, cb_config.ue_bluecorrection, cb_config.ue_filmslope, cb_config.ue_filmtoe, cb_config.ue_filmshoulder, cb_config.ue_filmblackclip, cb_config.ue_filmwhiteclip);
   }
 
-  tonemapped_prebluecorrect_ap1 = ApplyPostToneMapDesaturation(tonemapped_prebluecorrect_ap1);
-  tonemapped_prebluecorrect_ap1 = LerpToneMapStrength(tonemapped_prebluecorrect_ap1, untonemapped_prebluecorrect_ap1, cb_config);
-  tonemapped_ap1 = ApplyBlueCorrectionPost(tonemapped_prebluecorrect_ap1, cb_config.ue_bluecorrection);
+  tonemapped_blue_corrected_ap1 = ApplyPostToneMapDesaturation(tonemapped_blue_corrected_ap1);
+  tonemapped_blue_corrected_ap1 = LerpToneMapStrength(tonemapped_blue_corrected_ap1, untonemapped_blue_corrected_ap1, cb_config);
+  tonemapped_ap1 = ApplyBlueCorrectionPost(tonemapped_blue_corrected_ap1, cb_config.ue_bluecorrection);
   tonemapped_ap1 = max(0, tonemapped_ap1);
 
   // Moved to GenerateOutput
   // if (RENODX_TONE_MAP_TYPE != 0.f) {
   //   tonemapped_ap1 = ApplySaturationBlowoutHueCorrectionHighlightSaturationAP1(tonemapped_ap1, hue_reference_color, y, cg_config, RENODX_TONE_MAP_HUE_CORRECTION_TYPE);
   // }
-
-  tonemapped = tonemapped_ap1;
 
   return;
 }
@@ -154,6 +218,8 @@ renodx::lut::Config CreateSRGBInSRGBOutLUTConfig() {
   return lut_config;
 }
 
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 UnclampLegacy(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma) {
   const float3 added_gamma = black_gamma;
 
@@ -168,28 +234,49 @@ float3 UnclampLegacy(float3 original_gamma, float3 black_gamma, float3 mid_gray_
   return unclamped_gamma;
 }
 
-float3 UnclampYfAnchored(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma) {
-  const bool use_lms = RENODX_TONE_MAP_SCALING == 2.f;
-  const float3 lms_white = renodx::color::lms::from::BT709(1.f.xxx);
-  float3 original_working = use_lms ? renodx::color::lms::from::BT709(original_gamma) / lms_white : renodx::color::ap1::from::BT709(original_gamma);
-  float3 black_working = use_lms ? renodx::color::lms::from::BT709(black_gamma) / lms_white : renodx::color::ap1::from::BT709(black_gamma);
-  float3 mid_gray_working = use_lms ? renodx::color::lms::from::BT709(mid_gray_gamma) / lms_white : renodx::color::ap1::from::BT709(mid_gray_gamma);
-  float3 neutral_working = use_lms ? renodx::color::lms::from::BT709(neutral_gamma) / lms_white : renodx::color::ap1::from::BT709(neutral_gamma);
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
+float3 UnclampYfAnchoredAP1(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma, float blue_correction) {
+  float3 original_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(original_gamma, blue_correction);
+  float3 black_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(black_gamma, blue_correction);
+  float3 mid_gray_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(mid_gray_gamma, blue_correction);
+  float3 neutral_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(neutral_gamma, blue_correction);
 
-  float black_floor = min(black_working.r, min(black_working.g, black_working.b));
-  float mid_yf = use_lms ? renodx::color::yf::from::LMS(mid_gray_working) : renodx::color::yf::from::AP1(mid_gray_working);
-  float neutral_yf = use_lms ? renodx::color::yf::from::LMS(neutral_working) : renodx::color::yf::from::AP1(neutral_working);
+  float black_floor = min(black_blue_corrected_ap1.r, min(black_blue_corrected_ap1.g, black_blue_corrected_ap1.b));
+  float mid_yf = renodx::color::yf::from::AP1(mid_gray_blue_corrected_ap1);
+  float neutral_yf = renodx::color::yf::from::AP1(neutral_blue_corrected_ap1);
   float anchor_weight = mid_yf > 0.f ? saturate((mid_yf - neutral_yf) / mid_yf) : 0.f;
-  float3 unclamped_working = max(0.f, original_working - black_floor * anchor_weight);
+  float3 unclamped_blue_corrected_ap1 = max(0.f, original_blue_corrected_ap1 - black_floor * anchor_weight);
 
-  return use_lms
-             ? renodx::color::bt709::from::LMS(unclamped_working * lms_white)
-             : renodx::color::bt709::from::AP1(unclamped_working);
+  return BT709FromBlueCorrectedAP1(unclamped_blue_corrected_ap1, blue_correction);
 }
 
-float3 Unclamp(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma) {
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
+float3 UnclampYfAnchoredLMS(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma) {
+  const float3 lms_white = RENODX_BT709_LMS_WHITE;
+  float3 original_lms_normalized = renodx::color::lms::from::BT709(original_gamma) / lms_white;
+  float3 black_lms_normalized = renodx::color::lms::from::BT709(black_gamma) / lms_white;
+  float3 mid_gray_lms_normalized = renodx::color::lms::from::BT709(mid_gray_gamma) / lms_white;
+  float3 neutral_lms_normalized = renodx::color::lms::from::BT709(neutral_gamma) / lms_white;
+
+  float black_floor = min(black_lms_normalized.r, min(black_lms_normalized.g, black_lms_normalized.b));
+  float mid_yf = renodx::color::yf::from::LMS(mid_gray_lms_normalized * lms_white);
+  float neutral_yf = renodx::color::yf::from::LMS(neutral_lms_normalized * lms_white);
+  float anchor_weight = mid_yf > 0.f ? saturate((mid_yf - neutral_yf) / mid_yf) : 0.f;
+  float3 unclamped_lms_normalized = max(0.f, original_lms_normalized - black_floor * anchor_weight);
+
+  return renodx::color::bt709::from::LMS(unclamped_lms_normalized * lms_white);
+}
+
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
+float3 Unclamp(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma, float blue_correction) {
   if (CUSTOM_LUT_SCALING_METHOD == 1.f) {
-    return UnclampYfAnchored(original_gamma, black_gamma, mid_gray_gamma, neutral_gamma);
+    if (RENODX_TONE_MAP_SCALING == 2.f) {
+      return UnclampYfAnchoredLMS(original_gamma, black_gamma, mid_gray_gamma, neutral_gamma);
+    }
+    return UnclampYfAnchoredAP1(original_gamma, black_gamma, mid_gray_gamma, neutral_gamma, blue_correction);
   }
   return UnclampLegacy(original_gamma, black_gamma, mid_gray_gamma, neutral_gamma);
 }
@@ -201,55 +288,87 @@ float3 ApplyUnclampedScaling(float3 original_linear, float3 unclamped_linear, fl
   return lerp(original_linear, unclamped_linear, saturate(strength));
 }
 
-float3 ComputeGamutCompressionScaleAndCompress(float3 color_linear, inout float gamut_compression_scale) {
-  // if (RENODX_TONE_MAP_TYPE == 4.f || CUSTOM_LUT_GAMUT_RESTORATION == 0.f || !is_hdr) return color_linear;
-  if (CUSTOM_LUT_GAMUT_RESTORATION == 0.f) return color_linear;
+struct LUTBridgeState {
+  float3 adaptive_state_lms;
+  float gamut_compression_scale;
+  float max_channel_scale;
+};
 
-  const float MID_GRAY_GAMMA = log(1 / (pow(10, 0.75))) / log(0.5f);  // ~2.49f
+// input: BT.709 linear
+// output: compressed BT.709 linear
+float3 PrepareLUTInput(float3 color_bt709, out LUTBridgeState state) {
+  state.adaptive_state_lms = renodx::color::lms::from::BT709(0.18f.xxx);
+  state.gamut_compression_scale = 1.f;
 
-  float3 encoded = renodx::color::gamma::EncodeSafe(color_linear, MID_GRAY_GAMMA);
-  float encoded_gray = renodx::color::gamma::Encode(renodx::color::y::from::BT709(color_linear), MID_GRAY_GAMMA);
+  if (CUSTOM_LUT_GAMUT_RESTORATION != 0.f) {
+    if (CUSTOM_LUT_GAMUT_COMPRESSION_METHOD == 0.f) {
+      const float mid_gray_gamma = log(1.f / pow(10.f, 0.75f)) / log(0.5f);
+      float3 encoded = renodx::color::gamma::EncodeSafe(color_bt709, mid_gray_gamma);
+      float encoded_gray = renodx::color::gamma::Encode(
+          renodx::color::y::from::BT709(color_bt709),
+          mid_gray_gamma);
+      state.gamut_compression_scale = renodx::color::correct::ComputeGamutCompressionScale(
+          encoded,
+          encoded_gray);
+      color_bt709 = renodx::color::gamma::DecodeSafe(
+          renodx::color::correct::GamutCompress(
+              encoded,
+              encoded_gray,
+              state.gamut_compression_scale),
+          mid_gray_gamma);
+    } else {
+      state.gamut_compression_scale = renodx::color::gamut::ComputeGamutCompressionScaleBT709AdaptiveD65(
+          color_bt709,
+          state.adaptive_state_lms,
+          1.f);
+      color_bt709 = renodx::color::gamut::GamutCompressBT709AdaptiveD65(
+          color_bt709,
+          state.adaptive_state_lms,
+          state.gamut_compression_scale);
+    }
+  }
 
-  gamut_compression_scale = renodx::color::correct::ComputeGamutCompressionScale(encoded, encoded_gray);
-
-  float3 compressed = renodx::color::correct::GamutCompress(encoded, encoded_gray, gamut_compression_scale);
-
-  return renodx::color::gamma::DecodeSafe(compressed, MID_GRAY_GAMMA);
+  state.max_channel_scale = renodx::tonemap::neutwo::ComputeMaxChannelScale(color_bt709);
+  return color_bt709 * state.max_channel_scale;
 }
 
-float3 GamutDecompress(float3 color_linear, float gamut_compression_scale) {
-  // if (RENODX_TONE_MAP_TYPE == 4.f || CUSTOM_LUT_GAMUT_RESTORATION == 0.f || !is_hdr) return color_linear;
-  if (CUSTOM_LUT_GAMUT_RESTORATION == 0.f) return color_linear;
+// input: compressed BT.709 linear
+// output: restored BT.709 linear
+float3 RestoreLUTOutput(float3 color_bt709, LUTBridgeState state) {
+  color_bt709 = renodx::math::DivideSafe(
+      color_bt709,
+      state.max_channel_scale.xxx,
+      color_bt709);
+  if (CUSTOM_LUT_GAMUT_RESTORATION == 0.f) return color_bt709;
 
-  const float MID_GRAY_GAMMA = log(1 / (pow(10, 0.75))) / log(0.5f);  // ~2.49f
+  if (CUSTOM_LUT_GAMUT_COMPRESSION_METHOD == 0.f) {
+    const float mid_gray_gamma = log(1.f / pow(10.f, 0.75f)) / log(0.5f);
+    float3 encoded = renodx::color::gamma::EncodeSafe(color_bt709, mid_gray_gamma);
+    float encoded_gray = renodx::color::gamma::Encode(
+        renodx::color::y::from::BT709(color_bt709),
+        mid_gray_gamma);
+    return renodx::color::gamma::DecodeSafe(
+        renodx::color::correct::GamutDecompress(
+            encoded,
+            encoded_gray,
+            state.gamut_compression_scale),
+        mid_gray_gamma);
+  }
 
-  float3 encoded = renodx::color::gamma::EncodeSafe(color_linear, MID_GRAY_GAMMA);
-  float encoded_gray = renodx::color::gamma::Encode(renodx::color::y::from::BT709(color_linear), MID_GRAY_GAMMA);
-
-  float3 decompressed = renodx::color::correct::GamutDecompress(encoded, encoded_gray, gamut_compression_scale);
-
-  return renodx::color::gamma::DecodeSafe(decompressed, MID_GRAY_GAMMA);
-}
-
-float3 ComputeMaxChannelScaleAndCompress(float3 color_srgb, inout float channel_compression_scale) {
-  // if (RENODX_TONE_MAP_TYPE != 4.f && is_hdr) {
-  channel_compression_scale = renodx::math::Max(color_srgb.r, color_srgb.g, color_srgb.b, 1.f);
-  color_srgb /= channel_compression_scale;
-  // }
-  return color_srgb;
+  return renodx::color::gamut::GamutDecompressBT709AdaptiveD65(
+      color_bt709,
+      state.adaptive_state_lms,
+      state.gamut_compression_scale);
 }
 
 // single LUT
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 SamplePacked1DLut(
     float3 color_srgb,
     SamplerState lut_sampler,
     Texture2D<float4> lut_texture,
     UECbufferConfig cb_config) {
-  float max_channel = 1.f;
-  {
-    color_srgb = ComputeMaxChannelScaleAndCompress(color_srgb, max_channel);
-  }
-
   color_srgb = saturate(color_srgb);
 
   float _952 = (color_srgb.g * 0.9375f) + 0.03125f;
@@ -267,26 +386,17 @@ float3 SamplePacked1DLut(
 
   float3 lutted_srgb = float3(_992, _993, _994);
 
-  {
-    lutted_srgb *= max_channel;
-  }
-
   return lutted_srgb;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 float3 SampleLUTSRGBInSRGBOut(Texture2D<float4> lut_texture, SamplerState lut_sampler, float3 color_input, UECbufferConfig cb_config) {
   renodx::lut::Config lut_config = CreateSRGBInSRGBOutLUTConfig();
-
-  float gamut_compression_scale = 1.f;
-  {
-    color_input = ComputeGamutCompressionScaleAndCompress(color_input, gamut_compression_scale);
-  }
 
   float3 lut_input_color = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lut_output_color = SamplePacked1DLut(lut_input_color, lut_config.lut_sampler, lut_texture, cb_config);
   float3 color_output = renodx::lut::LinearOutput(lut_output_color, lut_config);
-
-  color_output = GamutDecompress(color_output, gamut_compression_scale);
 
   [branch]
   if (lut_config.scaling != 0.f) {
@@ -298,21 +408,22 @@ float3 SampleLUTSRGBInSRGBOut(Texture2D<float4> lut_texture, SamplerState lut_sa
       float3 lut_mid = SamplePacked1DLut(lut_black, lut_config.lut_sampler, lut_texture, cb_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // account for EOTF emulation in inputs
-        lut_output_color = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(color_output), lut_config);
-        lut_black = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(lut_black_linear), lut_config);
-        lut_mid = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(renodx::lut::LinearOutput(lut_mid, lut_config)), lut_config);
+        lut_output_color = renodx::lut::ConvertInput(ApplyGammaCorrection(color_output, false, cb_config.ue_bluecorrection), lut_config);
+        lut_black = renodx::lut::ConvertInput(ApplyGammaCorrection(lut_black_linear, false, cb_config.ue_bluecorrection), lut_config);
+        lut_mid = renodx::lut::ConvertInput(ApplyGammaCorrection(renodx::lut::LinearOutput(lut_mid, lut_config), false, cb_config.ue_bluecorrection), lut_config);
       }
 
       float3 unclamped_gamma = Unclamp(
           renodx::lut::GammaOutput(lut_output_color, lut_config),
           renodx::lut::GammaOutput(lut_black, lut_config),
           renodx::lut::GammaOutput(lut_mid, lut_config),
-          renodx::lut::ConvertInput(color_input, lut_config));
+          renodx::lut::ConvertInput(color_input, lut_config),
+          cb_config.ue_bluecorrection);
 
       float3 unclamped_linear = renodx::lut::LinearUnclampedOutput(unclamped_gamma, lut_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // inverse EOTF emulation
-        unclamped_linear = renodx::color::correct::GammaSafe(unclamped_linear, true);
+        unclamped_linear = ApplyGammaCorrection(unclamped_linear, true, cb_config.ue_bluecorrection);
       }
 
       color_output = ApplyUnclampedScaling(color_output, unclamped_linear, lut_config.scaling);
@@ -323,29 +434,25 @@ float3 SampleLUTSRGBInSRGBOut(Texture2D<float4> lut_texture, SamplerState lut_sa
   return color_output;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 void SampleLUTUpgradeToneMap(float3 color_lut_input, SamplerState lut_sampler, Texture2D<float4> lut_texture, inout float output_r, inout float output_g, inout float output_b, UECbufferConfig cb_config) {
-  float3 color_output = color_lut_input;
+  LUTBridgeState bridge_state;
+  float3 lut_input = PrepareLUTInput(color_lut_input, bridge_state);
+  float3 lutted = SampleLUTSRGBInSRGBOut(lut_texture, lut_sampler, lut_input, cb_config);
+  float3 color_output = lerp(
+      color_lut_input,
+      RestoreLUTOutput(lutted, bridge_state),
+      saturate(CUSTOM_LUT_STRENGTH));
 
-  // Clip lut if SDR
-  if (RENODX_TONE_MAP_TYPE == 0.f) {
-    float3 sdr_lut = SampleLUTSRGBInSRGBOut(lut_texture, lut_sampler, color_lut_input, cb_config);
-    color_output = saturate(lerp(color_lut_input, sdr_lut, saturate(CUSTOM_LUT_STRENGTH)));
-  } else {
-    float scale = renodx::tonemap::neutwo::ComputeMaxChannelScale(color_lut_input);
-
-    float3 color_lut_input_tonemapped = (color_lut_input * scale);  // Tonemap MaxCh to 1
-
-    float3 lutted = SampleLUTSRGBInSRGBOut(lut_texture, lut_sampler, color_lut_input_tonemapped, cb_config);
-
-    float3 lutted_inversed = (lutted / scale);  // Inverse scale
-
-    color_output = lerp(color_lut_input, lutted_inversed, saturate(CUSTOM_LUT_STRENGTH));
-  }
+  if (RENODX_TONE_MAP_TYPE == 0.f) color_output = saturate(color_output);
 
   output_r = color_output.r, output_g = color_output.g, output_b = color_output.b;
 }
 
 // blending 2 LUTs
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 Sample2Packed1DLuts(
     float3 color_srgb,
     SamplerState lut_sampler1,
@@ -353,11 +460,6 @@ float3 Sample2Packed1DLuts(
     Texture2D<float4> lut_texture1,
     Texture2D<float4> lut_texture2,
     UECbufferConfig cb_config) {
-  float max_channel = 1.f;
-  {
-    color_srgb = ComputeMaxChannelScaleAndCompress(color_srgb, max_channel);
-  }
-
   color_srgb = saturate(color_srgb);
 
   float _928 = color_srgb.r;
@@ -384,26 +486,17 @@ float3 Sample2Packed1DLuts(
 
   float3 lutted_srgb = float3(_1023, _1024, _1025);
 
-  {
-    lutted_srgb *= max_channel;
-  }
-
   return lutted_srgb;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 float3 Sample2LUTSRGBInSRGBOut(Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, SamplerState lut_sampler1, SamplerState lut_sampler2, float3 color_input, UECbufferConfig cb_config) {
   renodx::lut::Config lut_config = CreateSRGBInSRGBOutLUTConfig();
-
-  float gamut_compression_scale = 1.f;
-  {
-    color_input = ComputeGamutCompressionScaleAndCompress(color_input, gamut_compression_scale);
-  }
 
   float3 lut_input_color = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lut_output_color = Sample2Packed1DLuts(lut_input_color, lut_sampler1, lut_sampler2, lut_texture1, lut_texture2, cb_config);
   float3 color_output = renodx::lut::LinearOutput(lut_output_color, lut_config);
-
-  color_output = GamutDecompress(color_output, gamut_compression_scale);
 
   [branch]
   if (lut_config.scaling != 0.f) {
@@ -415,21 +508,22 @@ float3 Sample2LUTSRGBInSRGBOut(Texture2D<float4> lut_texture1, Texture2D<float4>
       float3 lut_mid = Sample2Packed1DLuts(lut_black, lut_sampler1, lut_sampler2, lut_texture1, lut_texture2, cb_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // account for EOTF emulation in inputs
-        lut_output_color = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(color_output), lut_config);
-        lut_black = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(lut_black_linear), lut_config);
-        lut_mid = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(renodx::lut::LinearOutput(lut_mid, lut_config)), lut_config);
+        lut_output_color = renodx::lut::ConvertInput(ApplyGammaCorrection(color_output, false, cb_config.ue_bluecorrection), lut_config);
+        lut_black = renodx::lut::ConvertInput(ApplyGammaCorrection(lut_black_linear, false, cb_config.ue_bluecorrection), lut_config);
+        lut_mid = renodx::lut::ConvertInput(ApplyGammaCorrection(renodx::lut::LinearOutput(lut_mid, lut_config), false, cb_config.ue_bluecorrection), lut_config);
       }
 
       float3 unclamped_gamma = Unclamp(
           renodx::lut::GammaOutput(lut_output_color, lut_config),
           renodx::lut::GammaOutput(lut_black, lut_config),
           renodx::lut::GammaOutput(lut_mid, lut_config),
-          renodx::lut::ConvertInput(color_input, lut_config));
+          renodx::lut::ConvertInput(color_input, lut_config),
+          cb_config.ue_bluecorrection);
 
       float3 unclamped_linear = renodx::lut::LinearUnclampedOutput(unclamped_gamma, lut_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // inverse EOTF emulation
-        unclamped_linear = renodx::color::correct::GammaSafe(unclamped_linear, true);
+        unclamped_linear = ApplyGammaCorrection(unclamped_linear, true, cb_config.ue_bluecorrection);
       }
 
       color_output = ApplyUnclampedScaling(color_output, unclamped_linear, lut_config.scaling);
@@ -440,28 +534,31 @@ float3 Sample2LUTSRGBInSRGBOut(Texture2D<float4> lut_texture1, Texture2D<float4>
   return color_output;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 void Sample2LUTsUpgradeToneMap(float3 color_lut_input, SamplerState lut_sampler1, SamplerState lut_sampler2, Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, inout float output_r, inout float output_g, inout float output_b, UECbufferConfig cb_config) {
-  float3 color_output = color_lut_input;
+  LUTBridgeState bridge_state;
+  float3 lut_input = PrepareLUTInput(color_lut_input, bridge_state);
+  float3 lutted = Sample2LUTSRGBInSRGBOut(
+      lut_texture1,
+      lut_texture2,
+      lut_sampler1,
+      lut_sampler2,
+      lut_input,
+      cb_config);
+  float3 color_output = lerp(
+      color_lut_input,
+      RestoreLUTOutput(lutted, bridge_state),
+      saturate(CUSTOM_LUT_STRENGTH));
 
-  if (RENODX_TONE_MAP_TYPE == 0.f) {
-    float3 sdr_lut = Sample2LUTSRGBInSRGBOut(lut_texture1, lut_texture2, lut_sampler1, lut_sampler2, color_lut_input, cb_config);
-    color_output = saturate(lerp(color_lut_input, sdr_lut, saturate(CUSTOM_LUT_STRENGTH)));
-  } else {
-    float scale = renodx::tonemap::neutwo::ComputeMaxChannelScale(color_lut_input);
-
-    float3 color_lut_input_tonemapped = (color_lut_input * scale);  // Tonemap MaxCh to 1
-
-    float3 lutted = Sample2LUTSRGBInSRGBOut(lut_texture1, lut_texture2, lut_sampler1, lut_sampler2, color_lut_input_tonemapped, cb_config);
-
-    float3 lutted_inversed = (lutted / scale);  // Inverse scale
-
-    color_output = lerp(color_lut_input, lutted_inversed, saturate(CUSTOM_LUT_STRENGTH));
-  }
+  if (RENODX_TONE_MAP_TYPE == 0.f) color_output = saturate(color_output);
 
   output_r = color_output.r, output_g = color_output.g, output_b = color_output.b;
 }
 
 // blending 3 LUTs
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 Sample3Packed1DLuts(
     float3 color_srgb,
     SamplerState Samplers_1,
@@ -471,11 +568,6 @@ float3 Sample3Packed1DLuts(
     Texture2D<float4> Textures_2,
     Texture2D<float4> Textures_3,
     UECbufferConfig cb_config) {
-  float max_channel = 1.f;
-  {
-    color_srgb = ComputeMaxChannelScaleAndCompress(color_srgb, max_channel);
-  }
-
   color_srgb = saturate(color_srgb);
 
   float _1189 = color_srgb.r, _1200 = color_srgb.g, _1211 = color_srgb.b;
@@ -501,23 +593,16 @@ float3 Sample3Packed1DLuts(
 
   float3 lutted_srgb = float3(_1305, _1306, _1307);
 
-  {
-    lutted_srgb *= max_channel;
-  }
-
   return lutted_srgb;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 float3 Sample3LUTSRGBInSRGBOut(
     Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3,
     SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3,
     float3 color_input, UECbufferConfig cb_config) {
   renodx::lut::Config lut_config = CreateSRGBInSRGBOutLUTConfig();
-
-  float gamut_compression_scale = 1.f;
-  {
-    color_input = ComputeGamutCompressionScaleAndCompress(color_input, gamut_compression_scale);
-  }
 
   float3 lut_input_color = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lut_output_color = Sample3Packed1DLuts(
@@ -526,8 +611,6 @@ float3 Sample3LUTSRGBInSRGBOut(
       lut_texture1, lut_texture2, lut_texture3,
       cb_config);
   float3 color_output = renodx::lut::LinearOutput(lut_output_color, lut_config);
-
-  color_output = GamutDecompress(color_output, gamut_compression_scale);
 
   [branch]
   if (lut_config.scaling != 0.f) {
@@ -545,21 +628,22 @@ float3 Sample3LUTSRGBInSRGBOut(
                                            cb_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // account for EOTF emulation in inputs
-        lut_output_color = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(color_output), lut_config);
-        lut_black = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(lut_black_linear), lut_config);
-        lut_mid = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(renodx::lut::LinearOutput(lut_mid, lut_config)), lut_config);
+        lut_output_color = renodx::lut::ConvertInput(ApplyGammaCorrection(color_output, false, cb_config.ue_bluecorrection), lut_config);
+        lut_black = renodx::lut::ConvertInput(ApplyGammaCorrection(lut_black_linear, false, cb_config.ue_bluecorrection), lut_config);
+        lut_mid = renodx::lut::ConvertInput(ApplyGammaCorrection(renodx::lut::LinearOutput(lut_mid, lut_config), false, cb_config.ue_bluecorrection), lut_config);
       }
 
       float3 unclamped_gamma = Unclamp(
           renodx::lut::GammaOutput(lut_output_color, lut_config),
           renodx::lut::GammaOutput(lut_black, lut_config),
           renodx::lut::GammaOutput(lut_mid, lut_config),
-          renodx::lut::ConvertInput(color_input, lut_config));
+          renodx::lut::ConvertInput(color_input, lut_config),
+          cb_config.ue_bluecorrection);
 
       float3 unclamped_linear = renodx::lut::LinearUnclampedOutput(unclamped_gamma, lut_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // inverse EOTF emulation
-        unclamped_linear = renodx::color::correct::GammaSafe(unclamped_linear, true);
+        unclamped_linear = ApplyGammaCorrection(unclamped_linear, true, cb_config.ue_bluecorrection);
       }
 
       color_output = ApplyUnclampedScaling(color_output, unclamped_linear, lut_config.scaling);
@@ -570,41 +654,33 @@ float3 Sample3LUTSRGBInSRGBOut(
   return color_output;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 void Sample3LUTsUpgradeToneMap(
     float3 color_lut_input,
     SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3,
     Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3,
     inout float output_r, inout float output_g, inout float output_b, UECbufferConfig cb_config) {
-  float3 color_output = color_lut_input;
+  LUTBridgeState bridge_state;
+  float3 lut_input = PrepareLUTInput(color_lut_input, bridge_state);
+  float3 lutted = Sample3LUTSRGBInSRGBOut(
+      lut_texture1, lut_texture2, lut_texture3,
+      lut_sampler1, lut_sampler2, lut_sampler3,
+      lut_input,
+      cb_config);
+  float3 color_output = lerp(
+      color_lut_input,
+      RestoreLUTOutput(lutted, bridge_state),
+      saturate(CUSTOM_LUT_STRENGTH));
 
-  if (RENODX_TONE_MAP_TYPE == 0.f) {
-    float3 sdr_lut = Sample3LUTSRGBInSRGBOut(
-        lut_texture1, lut_texture2, lut_texture3,
-        lut_sampler1, lut_sampler2, lut_sampler3,
-        color_lut_input,
-        cb_config);
-
-    color_output = saturate(lerp(color_lut_input, sdr_lut, saturate(CUSTOM_LUT_STRENGTH)));
-  } else {
-    float scale = renodx::tonemap::neutwo::ComputeMaxChannelScale(color_lut_input);
-
-    float3 color_lut_input_tonemapped = (color_lut_input * scale);  // Tonemap MaxCh to 1
-
-    float3 lutted = Sample3LUTSRGBInSRGBOut(
-        lut_texture1, lut_texture2, lut_texture3,
-        lut_sampler1, lut_sampler2, lut_sampler3,
-        color_lut_input_tonemapped,
-        cb_config);
-
-    float3 lutted_inversed = (lutted / scale);  // Inverse scale
-
-    color_output = lerp(color_lut_input, lutted_inversed, saturate(CUSTOM_LUT_STRENGTH));
-  }
+  if (RENODX_TONE_MAP_TYPE == 0.f) color_output = saturate(color_output);
 
   output_r = color_output.r, output_g = color_output.g, output_b = color_output.b;
 }
 
 // // blending 4 LUTs
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 Sample4Packed1DLuts(
     float3 color_srgb,
     SamplerState Samplers_1,
@@ -616,11 +692,6 @@ float3 Sample4Packed1DLuts(
     Texture2D<float4> Textures_3,
     Texture2D<float4> Textures_4,
     UECbufferConfig cb_config) {
-  float max_channel = 1.f;
-  {
-    color_srgb = ComputeMaxChannelScaleAndCompress(color_srgb, max_channel);
-  }
-
   color_srgb = saturate(color_srgb);
 
   float _884 = color_srgb.r, _895 = color_srgb.g, _906 = color_srgb.b;
@@ -645,23 +716,16 @@ float3 Sample4Packed1DLuts(
 
   float3 lutted_srgb = float3(_1027, _1028, _1029);
 
-  {
-    lutted_srgb *= max_channel;
-  }
-
   return lutted_srgb;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 float3 Sample4LUTSRGBInSRGBOut(
     Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3, Texture2D<float4> lut_texture4,
     SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3, SamplerState lut_sampler4,
     float3 color_input, UECbufferConfig cb_config) {
   renodx::lut::Config lut_config = CreateSRGBInSRGBOutLUTConfig();
-
-  float gamut_compression_scale = 1.f;
-  {
-    color_input = ComputeGamutCompressionScaleAndCompress(color_input, gamut_compression_scale);
-  }
 
   float3 lut_input_color = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lut_output_color = Sample4Packed1DLuts(
@@ -670,8 +734,6 @@ float3 Sample4LUTSRGBInSRGBOut(
       lut_texture1, lut_texture2, lut_texture3, lut_texture4,
       cb_config);
   float3 color_output = renodx::lut::LinearOutput(lut_output_color, lut_config);
-
-  color_output = GamutDecompress(color_output, gamut_compression_scale);
 
   [branch]
   if (lut_config.scaling != 0.f) {
@@ -689,21 +751,22 @@ float3 Sample4LUTSRGBInSRGBOut(
                                            cb_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // account for EOTF emulation in inputs
-        lut_output_color = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(color_output), lut_config);
-        lut_black = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(lut_black_linear), lut_config);
-        lut_mid = renodx::lut::ConvertInput(renodx::color::correct::GammaSafe(renodx::lut::LinearOutput(lut_mid, lut_config)), lut_config);
+        lut_output_color = renodx::lut::ConvertInput(ApplyGammaCorrection(color_output, false, cb_config.ue_bluecorrection), lut_config);
+        lut_black = renodx::lut::ConvertInput(ApplyGammaCorrection(lut_black_linear, false, cb_config.ue_bluecorrection), lut_config);
+        lut_mid = renodx::lut::ConvertInput(ApplyGammaCorrection(renodx::lut::LinearOutput(lut_mid, lut_config), false, cb_config.ue_bluecorrection), lut_config);
       }
 
       float3 unclamped_gamma = Unclamp(
           renodx::lut::GammaOutput(lut_output_color, lut_config),
           renodx::lut::GammaOutput(lut_black, lut_config),
           renodx::lut::GammaOutput(lut_mid, lut_config),
-          renodx::lut::ConvertInput(color_input, lut_config));
+          renodx::lut::ConvertInput(color_input, lut_config),
+          cb_config.ue_bluecorrection);
 
       float3 unclamped_linear = renodx::lut::LinearUnclampedOutput(unclamped_gamma, lut_config);
 
       if (RENODX_GAMMA_CORRECTION != 0.f) {  // inverse EOTF emulation
-        unclamped_linear = renodx::color::correct::GammaSafe(unclamped_linear, true);
+        unclamped_linear = ApplyGammaCorrection(unclamped_linear, true, cb_config.ue_bluecorrection);
       }
 
       color_output = ApplyUnclampedScaling(color_output, unclamped_linear, lut_config.scaling);
@@ -714,35 +777,26 @@ float3 Sample4LUTSRGBInSRGBOut(
   return color_output;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 void Sample4LUTsUpgradeToneMap(
     float3 color_lut_input,
     SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3, SamplerState lut_sampler4,
     Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3, Texture2D<float4> lut_texture4,
     inout float output_r, inout float output_g, inout float output_b, UECbufferConfig cb_config) {
-  float3 color_output = color_lut_input;
+  LUTBridgeState bridge_state;
+  float3 lut_input = PrepareLUTInput(color_lut_input, bridge_state);
+  float3 lutted = Sample4LUTSRGBInSRGBOut(
+      lut_texture1, lut_texture2, lut_texture3, lut_texture4,
+      lut_sampler1, lut_sampler2, lut_sampler3, lut_sampler4,
+      lut_input,
+      cb_config);
+  float3 color_output = lerp(
+      color_lut_input,
+      RestoreLUTOutput(lutted, bridge_state),
+      saturate(CUSTOM_LUT_STRENGTH));
 
-  if (RENODX_TONE_MAP_TYPE == 0.f) {
-    float3 sdr_lut = Sample4LUTSRGBInSRGBOut(
-        lut_texture1, lut_texture2, lut_texture3, lut_texture4,
-        lut_sampler1, lut_sampler2, lut_sampler3, lut_sampler4,
-        color_lut_input,
-        cb_config);
-    color_output = saturate(lerp(color_lut_input, sdr_lut, saturate(CUSTOM_LUT_STRENGTH)));
-  } else {
-    float scale = renodx::tonemap::neutwo::ComputeMaxChannelScale(color_lut_input);
-
-    float3 color_lut_input_tonemapped = (color_lut_input * scale);  // Tonemap MaxCh to 1
-
-    float3 lutted = Sample4LUTSRGBInSRGBOut(
-        lut_texture1, lut_texture2, lut_texture3, lut_texture4,
-        lut_sampler1, lut_sampler2, lut_sampler3, lut_sampler4,
-        color_lut_input_tonemapped,
-        cb_config);
-
-    float3 lutted_inversed = (lutted / scale);  // Inverse scale
-
-    color_output = lerp(color_lut_input, lutted_inversed, saturate(CUSTOM_LUT_STRENGTH));
-  }
+  if (RENODX_TONE_MAP_TYPE == 0.f) color_output = saturate(color_output);
 
   output_r = color_output.r, output_g = color_output.g, output_b = color_output.b;
 }

--- a/src/games/ue-extended/lutbuilder/filmtonemap.hlsli
+++ b/src/games/ue-extended/lutbuilder/filmtonemap.hlsli
@@ -190,16 +190,24 @@ float3 ApplyExtendedToneCurveAP1(
 float3 ApplyExtendedToneCurveLMS(
   float3 untonemapped_lms_normalized,
   unrealengine::filmtonemap::Config filmic_params) {
+    // AP1 clamp is needed to prevent NaNs. Emulates RRT clamping behavior.
+  float3 clamped_ap1 = clamp(
+    renodx::color::ap1::from::LMS(
+      untonemapped_lms_normalized * RENODX_BT709_LMS_WHITE),
+    0.f,
+    renodx::math::FLT16_MAX);
+  float3 curve_input_lms_normalized =
+    renodx::color::lms::from::AP1(clamped_ap1) / RENODX_BT709_LMS_WHITE;
   float3 vanilla_lms_normalized = unrealengine::filmtonemap::ApplyToneCurve(
-    untonemapped_lms_normalized,
+    curve_input_lms_normalized,
       filmic_params);
   float3 tonemapped_lms_normalized = unrealengine::filmtonemap::extended::ApplyToneCurveExtended(
-    untonemapped_lms_normalized,
+    curve_input_lms_normalized,
     vanilla_lms_normalized,
       filmic_params);
 
   return RestorePsychoHueAndCompressLMS(
-    untonemapped_lms_normalized,
+    curve_input_lms_normalized,
     lerp(
       tonemapped_lms_normalized,
       vanilla_lms_normalized,

--- a/src/games/ue-extended/lutbuilder/filmtonemap.hlsli
+++ b/src/games/ue-extended/lutbuilder/filmtonemap.hlsli
@@ -92,8 +92,8 @@ FILMTONECURVE_GENERATOR(float3)
 float3 ApplyToneCurve(
     float3 untonemapped,
     float FilmSlope, float FilmToe, float FilmShoulder, float FilmBlackClip, float FilmWhiteClip) {
-  unrealengine::filmtonemap::Config film_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
-  return ApplyToneCurve(untonemapped, film_params);
+  unrealengine::filmtonemap::Config filmic_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
+  return ApplyToneCurve(untonemapped, filmic_params);
 }
 
 namespace extended {
@@ -128,16 +128,16 @@ FILMTONECURVE_EXTENDED_GENERATOR(float3)
 float3 ApplyToneCurveExtended(
     float3 untonemapped,
     float FilmSlope, float FilmToe, float FilmShoulder, float FilmBlackClip, float FilmWhiteClip) {
-  unrealengine::filmtonemap::Config film_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
-  float3 vanilla = unrealengine::filmtonemap::ApplyToneCurve(untonemapped, film_params);
-  return ApplyToneCurveExtended(untonemapped, vanilla, film_params);
+  unrealengine::filmtonemap::Config filmic_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
+  float3 vanilla = unrealengine::filmtonemap::ApplyToneCurve(untonemapped, filmic_params);
+  return ApplyToneCurveExtended(untonemapped, vanilla, filmic_params);
 }
 
 float3 ApplyToneCurveExtended(
     float3 untonemapped, float3 vanilla,
     float FilmSlope, float FilmToe, float FilmShoulder, float FilmBlackClip, float FilmWhiteClip) {
-  unrealengine::filmtonemap::Config film_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
-  return ApplyToneCurveExtended(untonemapped, vanilla, film_params);
+  unrealengine::filmtonemap::Config filmic_params = config::Create(FilmSlope, FilmToe, FilmShoulder, FilmBlackClip, FilmWhiteClip);
+  return ApplyToneCurveExtended(untonemapped, vanilla, filmic_params);
 }
 
 }  // extended
@@ -146,59 +146,99 @@ float3 ApplyToneCurveExtended(
 
 }  // unrealengine
 
-float3 ApplyToneCurveExtendedWithHermite(
-    float3 untonemapped_rrt_prebluecorrect_ap1,
-    float3 untonemapped_prebluecorrect_ap1, float FilmSlope, float FilmToe,
-    float FilmShoulder, float FilmBlackClip, float FilmWhiteClip) {
-  float film_black_clip = FilmBlackClip;
-  if (OVERRIDE_BLACK_CLIP) film_black_clip = 0.f;
-  unrealengine::filmtonemap::Config film_params =
-      unrealengine::filmtonemap::config::Create(FilmSlope, FilmToe, FilmShoulder, film_black_clip, FilmWhiteClip);
+// input: blue-corrected AP1 linear
+// output: blue-corrected AP1 linear
+float3 ApplyExtendedToneCurveMaxChannel(
+  float3 tonemapped_blue_corrected_ap1,
+  float3 vanilla_blue_corrected_ap1,
+  float blue_correction) {
+  // Max Channel display mapping uses this reference to simulate hue/chroma blowout.
+  float3 bt709_hue_and_chrominance_source = BT709FromBlueCorrectedAP1(
+    renodx::tonemap::ReinhardPiecewise(tonemapped_blue_corrected_ap1, RENODX_TONE_MAP_PER_CH_PEAK, 0.18f),
+    blue_correction);
 
-  float3 vanilla = unrealengine::filmtonemap::ApplyToneCurve(untonemapped_rrt_prebluecorrect_ap1, film_params);
-  float3 tonemapped_prebluecorrect_ap1 =
-      unrealengine::filmtonemap::extended::ApplyToneCurveExtended(untonemapped_rrt_prebluecorrect_ap1, vanilla, film_params);
+  // UE games are extremely bright, and lerping toward vanilla helps reduce average picture brightness.
+  tonemapped_blue_corrected_ap1 = lerp(
+    tonemapped_blue_corrected_ap1,
+    vanilla_blue_corrected_ap1,
+    saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR))));
+
+  float3 bt709_tonemapped = BT709FromBlueCorrectedAP1(tonemapped_blue_corrected_ap1, blue_correction);
+  return BlueCorrectedAP1FromBT709(
+    HueAndChrominance(
+      bt709_tonemapped,
+      bt709_hue_and_chrominance_source,
+      saturate(RENODX_TONE_MAP_HUE_SHIFT),
+      saturate(RENODX_TONE_MAP_CHROMA_CORRECT_BLOWOUT),
+      1.f),
+    blue_correction);
+}
+
+// input: blue-corrected AP1 linear
+// output: blue-corrected AP1 linear
+float3 ApplyExtendedToneCurveAP1(
+  float3 tonemapped_blue_corrected_ap1,
+  float3 vanilla_blue_corrected_ap1) {
+  return lerp(
+    tonemapped_blue_corrected_ap1,
+    vanilla_blue_corrected_ap1,
+    saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR))));
+}
+
+// input: white-normalized LMS linear
+// output: white-normalized LMS linear
+float3 ApplyExtendedToneCurveLMS(
+  float3 untonemapped_lms_normalized,
+  unrealengine::filmtonemap::Config filmic_params) {
+  float3 vanilla_lms_normalized = unrealengine::filmtonemap::ApplyToneCurve(
+    untonemapped_lms_normalized,
+      filmic_params);
+  float3 tonemapped_lms_normalized = unrealengine::filmtonemap::extended::ApplyToneCurveExtended(
+    untonemapped_lms_normalized,
+    vanilla_lms_normalized,
+      filmic_params);
+
+  return RestorePsychoHueAndCompressLMS(
+    untonemapped_lms_normalized,
+    lerp(
+      tonemapped_lms_normalized,
+      vanilla_lms_normalized,
+      saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR)))),
+    RENODX_TONE_MAP_HUE_RESTORE);
+}
+
+// input: RRT value in blue-corrected AP1 linear
+// output: blue-corrected AP1 linear
+float3 ApplyToneCurveExtendedWithHermite(
+  float3 untonemapped_rrt_blue_corrected_ap1,
+  float blue_correction,
+  float FilmSlope,
+  float FilmToe,
+  float FilmShoulder,
+  float FilmBlackClip,
+  float FilmWhiteClip) {
+  float filmic_black_clip = FilmBlackClip;
+  if (OVERRIDE_BLACK_CLIP) filmic_black_clip = 0.f;
+  unrealengine::filmtonemap::Config filmic_params =
+      unrealengine::filmtonemap::config::Create(FilmSlope, FilmToe, FilmShoulder, filmic_black_clip, FilmWhiteClip);
+
+  float3 vanilla_blue_corrected_ap1 = unrealengine::filmtonemap::ApplyToneCurve(
+    untonemapped_rrt_blue_corrected_ap1,
+      filmic_params);
+  float3 tonemapped_blue_corrected_ap1 = unrealengine::filmtonemap::extended::ApplyToneCurveExtended(
+    untonemapped_rrt_blue_corrected_ap1,
+    vanilla_blue_corrected_ap1,
+      filmic_params);
 
   if (RENODX_TONE_MAP_SCALING == 0.f) {
-    // Max Channel display mapping uses this reference to simulate hue/chroma blowout.
-    float3 bt709_hue_and_chrominance_source = renodx::color::bt709::from::AP1(
-        renodx::tonemap::ReinhardPiecewise(tonemapped_prebluecorrect_ap1, RENODX_TONE_MAP_PER_CH_PEAK, 0.18f));
-    // UE games are extremely bright, and lerping toward vanilla helps reduce average picture brightness.
-    tonemapped_prebluecorrect_ap1 = lerp(tonemapped_prebluecorrect_ap1,
-                                         vanilla,
-                                         saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR))));
-    float3 bt709_tonemapped_prebluecorrect = renodx::color::bt709::from::AP1(tonemapped_prebluecorrect_ap1);
-    tonemapped_prebluecorrect_ap1 = renodx::color::ap1::from::BT709(HueAndChrominanceOKLab(
-        bt709_tonemapped_prebluecorrect,
-        bt709_hue_and_chrominance_source,
-        saturate(RENODX_TONE_MAP_HUE_SHIFT),
-        saturate(RENODX_TONE_MAP_CHROMA_CORRECT_BLOWOUT),
-        1.f));
-  } else if (RENODX_TONE_MAP_SCALING == 2.f) {
-    const float3 lms_white = renodx::color::lms::from::BT709(1.f.xxx);
-    float3 untonemapped_lms_normalized =
-        renodx::color::lms::from::AP1(untonemapped_prebluecorrect_ap1) / lms_white;
-    float3 tonemapped_lms_normalized =
-        renodx::color::lms::from::AP1(tonemapped_prebluecorrect_ap1) / lms_white;
-    float3 vanilla_lms_normalized = unrealengine::filmtonemap::ApplyToneCurve(
-        untonemapped_lms_normalized,
-        film_params);
-    vanilla_lms_normalized = RestorePsychoHueAndCompressLMS(
-        untonemapped_lms_normalized,
-        vanilla_lms_normalized,
-        RENODX_TONE_MAP_HUE_RESTORE);
-    tonemapped_prebluecorrect_ap1 = renodx::color::ap1::from::LMS(
-        lerp(tonemapped_lms_normalized,
-             vanilla_lms_normalized,
-             saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR))))
-        * lms_white);
-  } else {
-    tonemapped_prebluecorrect_ap1 = lerp(tonemapped_prebluecorrect_ap1,
-                                         vanilla,
-                                         saturate(lerp(0.75f, 0.f, saturate(BLEND_FACTOR))));
+    return ApplyExtendedToneCurveMaxChannel(
+      tonemapped_blue_corrected_ap1,
+      vanilla_blue_corrected_ap1,
+      blue_correction);
   }
-
-  return tonemapped_prebluecorrect_ap1;
+  return ApplyExtendedToneCurveAP1(
+    tonemapped_blue_corrected_ap1,
+    vanilla_blue_corrected_ap1);
 }
 
 #endif  // INCLUDE_FILMTONEMAP

--- a/src/games/ue-extended/lutbuilder/lutbuildercommon.hlsli
+++ b/src/games/ue-extended/lutbuilder/lutbuildercommon.hlsli
@@ -1,67 +1,50 @@
-#include "../shared.h"
+#include "../common.hlsli"
 
 #ifndef INCLUDE_LUTBUILDER_COMMON
 #define INCLUDE_LUTBUILDER_COMMON
 
 #include "./etcfunctions.hlsli"
 
-float3 ApplyBlueCorrectionPre(float3 untonemapped_ap1, float blue_correction) {
-  if (FORCE_BLUE_CORRECT == 1.f) {
-    blue_correction = 0.6f;
-  }
-
-  float r = untonemapped_ap1.r, g = untonemapped_ap1.g, b = untonemapped_ap1.b;
-
-  float corrected_r = ((mad(0.061360642313957214f, b, mad(-4.540197551250458e-09f, g, (r * 0.9386394023895264f))) - r) * blue_correction) + r;
-  float corrected_g = ((mad(0.169205904006958f, b, mad(0.8307942152023315f, g, (r * 6.775371730327606e-08f))) - g) * blue_correction) + g;
-  float corrected_b = (mad(-2.3283064365386963e-10f, g, (r * -9.313225746154785e-10f)) * blue_correction) + b;
-
-  return float3(corrected_r, corrected_g, corrected_b);
-}
-
-float3 ApplyBlueCorrectionPost(float3 tonemapped_ap1, float blue_correction) {
-  if (FORCE_BLUE_CORRECT == 1.f) {
-    blue_correction = 0.6f;
-  }
-
-  float r = tonemapped_ap1.r, g = tonemapped_ap1.g, b = tonemapped_ap1.b;
-
-  float corrected_r = ((mad(-0.06537103652954102f, b, mad(1.451815478503704e-06f, g, (r * 1.065374732017517f))) - r) * blue_correction) + r;
-  float corrected_g = ((mad(-0.20366770029067993f, b, mad(1.2036634683609009f, g, (r * -2.57161445915699e-07f))) - g) * blue_correction) + g;
-  float corrected_b = ((mad(0.9999996423721313f, b, mad(2.0954757928848267e-08f, g, (r * 1.862645149230957e-08f))) - b) * blue_correction) + b;
-
-  return float3(corrected_r, corrected_g, corrected_b);
-}
-
-float3 HueAndChrominanceOKLab(
+float3 HueAndChrominance(
     float3 incorrect_color, float3 reference_color,
     float hue_correct_strength = 0.f,
     float chrominance_correct_strength = 0.f,
     float saturation = 1.f) {
   if (hue_correct_strength != 0.0 || chrominance_correct_strength != 0.0 || saturation != 0.0) {
-    float3 perceptual_new = renodx::color::oklab::from::BT709(incorrect_color);
-    const float3 reference_oklab = renodx::color::oklab::from::BT709(reference_color);
+    float3 perceptual_new;
+    float3 perceptual_reference;
+    if (RENODX_TONE_MAP_HUE_BLOWOUT_WORKING_SPACE == 0.f) {
+      perceptual_new = renodx::color::oklab::from::BT709(incorrect_color);
+      perceptual_reference = renodx::color::oklab::from::BT709(reference_color);
+    } else {
+      perceptual_new = renodx::color::ictcp::from::BT709(incorrect_color);
+      perceptual_reference = renodx::color::ictcp::from::BT709(reference_color);
+    }
 
     float chrominance_current = length(perceptual_new.yz);
     float chrominance_ratio = 1.0;
 
     if (hue_correct_strength != 0.0) {
       const float chrominance_pre = chrominance_current;
-      perceptual_new.yz = lerp(perceptual_new.yz, reference_oklab.yz, hue_correct_strength);
+      perceptual_new.yz = lerp(perceptual_new.yz, perceptual_reference.yz, hue_correct_strength);
       const float chrominancePost = length(perceptual_new.yz);
       chrominance_ratio = renodx::math::SafeDivision(chrominance_pre, chrominancePost, 1);
       chrominance_current = chrominancePost;
     }
 
     if (chrominance_correct_strength != 0.0) {
-      const float reference_chrominance = length(reference_oklab.yz);
+      const float reference_chrominance = length(perceptual_reference.yz);
       float target_chrominance_ratio = renodx::math::SafeDivision(reference_chrominance, chrominance_current, 1);
       chrominance_ratio = lerp(chrominance_ratio, target_chrominance_ratio, chrominance_correct_strength);
     }
     perceptual_new.yz *= chrominance_ratio;
     perceptual_new.yz *= saturation;
 
-    incorrect_color = renodx::color::bt709::from::OkLab(perceptual_new);
+    if (RENODX_TONE_MAP_HUE_BLOWOUT_WORKING_SPACE == 0.f) {
+      incorrect_color = renodx::color::bt709::from::OkLab(perceptual_new);
+    } else {
+      incorrect_color = renodx::color::bt709::from::ICtCp(perceptual_new);
+    }
     incorrect_color = renodx::color::bt709::clamp::AP1(incorrect_color);
   }
   return incorrect_color;
@@ -243,6 +226,8 @@ float ComputeSaturationScale(float yf, float yf_peak, renodx::color::grade::Conf
   return scale;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
 float3 ApplySaturationMaxChannel(float3 color_bt709, float peak, renodx::color::grade::Config config) {
   float3 perceptual = renodx::color::oklab::from::BT709(max(0.f, color_bt709));
   float yf = renodx::color::yf::from::BT709(color_bt709);
@@ -250,21 +235,32 @@ float3 ApplySaturationMaxChannel(float3 color_bt709, float peak, renodx::color::
   return max(0.f, renodx::color::bt709::from::OkLab(perceptual));
 }
 
+// input: blue-corrected AP1 linear
+// output: blue-corrected AP1 linear
 float3 ApplySaturationAP1(float3 color_ap1, float peak, renodx::color::grade::Config config) {
   float yf = renodx::color::yf::from::AP1(color_ap1);
   return lerp(yf.xxx, color_ap1, ComputeSaturationScale(yf, renodx::color::yf::from::AP1(peak.xxx), config));
 }
 
+// input: white-normalized LMS linear
+// output: white-normalized LMS linear
 float3 ApplySaturationLMS(float3 color_lms_normalized, float peak, renodx::color::grade::Config config) {
-  float yf = renodx::color::yf::from::LMS(color_lms_normalized);
-  return lerp(yf.xxx, color_lms_normalized, ComputeSaturationScale(yf, renodx::color::yf::from::LMS(peak.xxx), config));
+  float yf_white = renodx::color::yf::from::LMS(RENODX_BT709_LMS_WHITE);
+  float yf = renodx::color::yf::from::LMS(color_lms_normalized * RENODX_BT709_LMS_WHITE);
+  float yf_peak = renodx::color::yf::from::LMS(peak.xxx * RENODX_BT709_LMS_WHITE);
+  float3 neutral_lms_normalized = renodx::math::DivideSafe(yf, yf_white, 0.f).xxx;
+  return lerp(neutral_lms_normalized, color_lms_normalized, ComputeSaturationScale(yf, yf_peak, config));
 }
 
+// input: white-normalized LMS linear
+// output: white-normalized LMS linear
 float3 RestorePsychoHueAndCompressLMS(
-    float3 source_lms,
-    float3 target_lms,
-    float hue_restore,
-    float3 adaptive_state_lms = 0.18f) {
+    float3 source_lms_normalized,
+    float3 target_lms_normalized,
+    float hue_restore) {
+  float3 source_lms = source_lms_normalized * RENODX_BT709_LMS_WHITE;
+  float3 target_lms = target_lms_normalized * RENODX_BT709_LMS_WHITE;
+  float3 adaptive_state_lms = 0.18f * RENODX_BT709_LMS_WHITE;
   float3 source_relative_weighted = renodx::tonemap::psychov::psycho22_ToAdaptiveRelativeWeightedLMS(source_lms, adaptive_state_lms);
   float3 target_relative_weighted = renodx::tonemap::psychov::psycho22_ToAdaptiveRelativeWeightedLMS(target_lms, adaptive_state_lms);
   float3 neutral_weighted = renodx::tonemap::psychov::psycho22_AdaptiveRelativeWeightedNeutral();
@@ -279,7 +275,7 @@ float3 RestorePsychoHueAndCompressLMS(
                          - mb_neutral;
   float3 reference_white_relative_weighted =
       renodx::tonemap::psychov::psycho22_ToAdaptiveRelativeWeightedLMS(
-          1.f.xxx,
+        RENODX_BT709_LMS_WHITE,
           adaptive_state_lms);
   float reference_white_y =
       reference_white_relative_weighted.x + reference_white_relative_weighted.y;
@@ -301,7 +297,8 @@ float3 RestorePsychoHueAndCompressLMS(
       1.f);
 
   return renodx::color::macleod_boynton::UnweighLMS(
-      renodx::tonemap::psychov::psycho22_FromAdaptiveRelativeWeightedLMS(target_relative_weighted, adaptive_state_lms));
+             renodx::tonemap::psychov::psycho22_FromAdaptiveRelativeWeightedLMS(target_relative_weighted, adaptive_state_lms))
+         / RENODX_BT709_LMS_WHITE;
 }
 
 renodx::color::grade::Config CreateColorGradingConfig() {
@@ -326,18 +323,8 @@ float3 GammaCorrectHuePreserving(float3 incorrect_color) {
   return result;
 }
 
-float3 ApplyGammaCorrection(float3 incorrect_color) {
-  float3 corrected_color;
-
-  if (RENODX_GAMMA_CORRECTION == 1.f) {
-    corrected_color = renodx::color::correct::GammaSafe(incorrect_color);
-  } else {
-    corrected_color = incorrect_color;
-  }
-
-  return corrected_color;
-}
-
+// input: BT.709 sRGB encoded
+// output: BT.709 sRGB encoded
 float3 ScaleScene(float3 color) {
   if (RENODX_DIFFUSE_WHITE_NITS != RENODX_GRAPHICS_WHITE_NITS) {
     color = renodx::color::gamma::DecodeSafe(color);
@@ -347,49 +334,79 @@ float3 ScaleScene(float3 color) {
   return color;
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
+float3 DisplayMapMaxChannel(float3 color_bt709, float peak_ratio) {
+  renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  float3 graded_bt709 = ApplySaturationMaxChannel(color_bt709, peak_ratio, cg_config);
+  float3 graded_bt2020 = renodx::color::bt2020::from::BT709(graded_bt709);
+  float3 displaymapped_bt2020 = renodx::tonemap::neutwo::MaxChannel(
+      max(0.f, graded_bt2020),
+      peak_ratio,
+      100.f);
+  return renodx::color::bt709::from::BT2020(displaymapped_bt2020);
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 DisplayMapAP1(float3 color_bt709, float peak_ratio, float blue_correction) {
+  renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  float3 color_blue_corrected_ap1 = BlueCorrectedAP1FromBT709(color_bt709, blue_correction);
+  float3 graded_blue_corrected_ap1 = ApplySaturationAP1(color_blue_corrected_ap1, peak_ratio, cg_config);
+  float3 displaymapped_blue_corrected_ap1 = renodx::tonemap::neutwo::PerChannel(
+      max(0.f, graded_blue_corrected_ap1),
+      peak_ratio);
+  return BT709FromBlueCorrectedAP1(displaymapped_blue_corrected_ap1, blue_correction);
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 DisplayMapLMS(float3 color_bt709, float peak_ratio) {
+  renodx::color::grade::Config cg_config = CreateColorGradingConfig();
+  const float3 lms_white = RENODX_BT709_LMS_WHITE;
+  float3 color_lms_normalized = renodx::color::lms::from::BT709(color_bt709) / lms_white;
+  float3 peak_lms_normalized = renodx::color::lms::from::BT709(peak_ratio.xxx) / lms_white;
+  float3 graded_lms_normalized = ApplySaturationLMS(color_lms_normalized, peak_ratio, cg_config);
+  float3 displaymapped_lms_normalized = renodx::tonemap::neutwo::PerChannel(
+      max(0.f, graded_lms_normalized),
+      peak_lms_normalized);
+  displaymapped_lms_normalized = RestorePsychoHueAndCompressLMS(
+      graded_lms_normalized,
+      displaymapped_lms_normalized,
+      RENODX_TONE_MAP_HUE_RESTORE);
+  return renodx::color::bt709::from::LMS(displaymapped_lms_normalized * lms_white);
+}
+
+// input: BT.709 linear
+// output: BT.709 linear
+float3 DisplayMapByScaling(float3 color_bt709, float peak_ratio, float blue_correction) {
+  if (RENODX_TONE_MAP_SCALING == 0.f) {
+    return DisplayMapMaxChannel(color_bt709, peak_ratio);
+  }
+  if (RENODX_TONE_MAP_SCALING == 1.f) {
+    return DisplayMapAP1(color_bt709, peak_ratio, blue_correction);
+  }
+  return DisplayMapLMS(color_bt709, peak_ratio);
+}
+
+// input: BT.709 linear
+// output: PQ-encoded BT.2020 or sRGB-encoded BT.709
 float4 GenerateOutput(float3 final_color, float3 untonemapped_ap1, inout float4 SV_Target, uint device, float blue_correction) {
   // Dont displaymap SDR.
   [branch]
   if (RENODX_TONE_MAP_TYPE != 0.f) {
     float peak_ratio = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
-    if (RENODX_GAMMA_CORRECTION) peak_ratio = renodx::color::correct::Gamma(peak_ratio, true);
+    if (RENODX_GAMMA_CORRECTION != 0.f) peak_ratio = ApplyGammaCorrection(peak_ratio.xxx, true, blue_correction).x;
 
-    float3 bt709_graded_color;
-    if (RENODX_TONE_MAP_SCALING == 0.f) {
-      renodx::color::grade::Config cg_config = CreateColorGradingConfig();
-      float3 graded_bt709 = ApplySaturationMaxChannel(final_color, peak_ratio, cg_config);
-      float3 graded_bt2020 = renodx::color::bt2020::from::BT709(graded_bt709);
-      float3 displaymapped_bt2020 = renodx::tonemap::neutwo::MaxChannel(max(0.f, graded_bt2020), peak_ratio, 100.f);
-      bt709_graded_color = renodx::color::bt709::from::BT2020(displaymapped_bt2020);
-    } else if (RENODX_TONE_MAP_SCALING == 1.f) {
-      renodx::color::grade::Config cg_config = CreateColorGradingConfig();
-      float3 bluecorrected_ap1 = ApplyBlueCorrectionPre(renodx::color::ap1::from::BT709(final_color), blue_correction);
-      float3 graded_ap1 = ApplySaturationAP1(bluecorrected_ap1, peak_ratio, cg_config);
-      float3 displaymapped_ap1 = renodx::tonemap::neutwo::PerChannel(max(0.f, graded_ap1), peak_ratio);
-      bt709_graded_color = renodx::color::bt709::from::AP1(ApplyBlueCorrectionPost(displaymapped_ap1, blue_correction));
-    } else {
-      renodx::color::grade::Config cg_config = CreateColorGradingConfig();
-      const float3 lms_white = renodx::color::lms::from::BT709(1.f.xxx);
-      float3 final_color_lms_normalized = renodx::color::lms::from::BT709(final_color) / lms_white;
-      float3 peak_lms_normalized = renodx::color::lms::from::BT709(peak_ratio.xxx) / lms_white;
-      float3 graded_lms_normalized = ApplySaturationLMS(final_color_lms_normalized, peak_ratio, cg_config);
-      float3 displaymapped_lms_normalized = renodx::tonemap::neutwo::PerChannel(max(0.f, graded_lms_normalized), peak_lms_normalized);
-      displaymapped_lms_normalized = RestorePsychoHueAndCompressLMS(
-          graded_lms_normalized,
-          displaymapped_lms_normalized,
-          RENODX_TONE_MAP_HUE_RESTORE);
-      bt709_graded_color = renodx::color::bt709::from::LMS(displaymapped_lms_normalized * lms_white);
-    }
-
-    final_color = bt709_graded_color;
+    final_color = min(DisplayMapByScaling(final_color, peak_ratio, blue_correction), peak_ratio);  // clamp per channel here to avoid max channel clamp later
+  } else {
+    final_color = saturate(final_color);
   }
-
-  if (RENODX_TONE_MAP_TYPE == 0.f) final_color = saturate(final_color);
 
   float3 encoded_color;
   [branch]
   if (PROCESSING_PATH == 0.f) {
-    final_color = ApplyGammaCorrection(final_color);
+    final_color = ApplyGammaCorrection(final_color, false, blue_correction);
     float3 bt2020_color = renodx::color::bt2020::from::BT709(final_color);
     encoded_color = renodx::color::pq::EncodeSafe(bt2020_color, RENODX_DIFFUSE_WHITE_NITS);
   } else {

--- a/src/games/ue-extended/lutbuilder/lutbuilderoutput.hlsli
+++ b/src/games/ue-extended/lutbuilder/lutbuilderoutput.hlsli
@@ -1,6 +1,8 @@
 #include "./filmiclutbuilder.hlsli"
 #include "./lutbuildercommon.hlsli"
 
+// input: untonemapped AP1 linear and processed BT.709 linear
+// output: BT.709 linear
 float4 ProcessOutputDevice89(float3 untonemapped_ap1, float3 processed, uint outputdevice, UECbufferConfig cb_config) {
   // 7 = Linear output (HDR)
   // 8 = Linear final color, no tone curve (HDR)
@@ -27,125 +29,108 @@ float4 ProcessOutputDevice89(float3 untonemapped_ap1, float3 processed, uint out
   return float4((output / 1.05f), 0.f);
 }
 
+// input: BT.709 linear
+// output: BT.709 linear
+float3 ApplyMappingAndOverlay(float3 color_bt709, UECbufferConfig cb_config) {
+  float3 scaled = cb_config.ue_colorscale.xyz
+                  * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * color_bt709))
+                      * color_bt709)
+                     + cb_config.ue_mappingpolynomial.z);
+  return ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
+}
+
+// input: untonemapped AP1 linear and processed BT.709 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
+float4 FinalizeLutbuilderOutput(
+    float3 untonemapped_ap1,
+    float3 processed_bt709,
+    UECbufferConfig cb_config,
+    float4 SV_Target,
+    uint outputdevice) {
+  float3 output_bt709 = ApplyMappingAndOverlay(processed_bt709, cb_config);
+
+  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
+  if (is_linear) {
+    return ProcessOutputDevice89(untonemapped_ap1, output_bt709, outputdevice, cb_config);
+  }
+
+  return GenerateOutput(
+      output_bt709,
+      untonemapped_ap1,
+      SV_Target,
+      outputdevice,
+      cb_config.ue_bluecorrection);
+}
+
 // No SDR Lut
+// input: AP1 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
 float4 ProcessLutbuilder(float3 untonemapped_ap1, UECbufferConfig cb_config, float4 SV_Target, uint outputdevice) {
   // The rare game uses linear output for some menus
   // So we will skip everything, and just return untonemapped
 
-  float3 tonemapped;
-
-  ApplyFilmToneMapWithBlueCorrect(untonemapped_ap1, tonemapped, cb_config);
+  float3 tonemapped_ap1;
+  ApplyFilmicToneMap(untonemapped_ap1, tonemapped_ap1, cb_config);
 
   // float _1161 = mad((WorkingColorSpace.FromAP1[0].z), _1151, mad((WorkingColorSpace.FromAP1[0].y), _1150, ((WorkingColorSpace.FromAP1[0].x) * _1149)));
   // float _1162 = mad((WorkingColorSpace.FromAP1[1].z), _1151, mad((WorkingColorSpace.FromAP1[1].y), _1150, ((WorkingColorSpace.FromAP1[1].x) * _1149)));
   // float _1163 = mad((WorkingColorSpace.FromAP1[2].z), _1151, mad((WorkingColorSpace.FromAP1[2].y), _1150, ((WorkingColorSpace.FromAP1[2].x) * _1149)));
-  float3 bt709_tonemapped = renodx::color::bt709::from::AP1(tonemapped);
-
-  float3 scaled = cb_config.ue_colorscale.xyz * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * bt709_tonemapped)) * bt709_tonemapped) + cb_config.ue_mappingpolynomial.z);
-
-  float3 output = ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
-
-  // Handle linear output device
-  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
-  if (is_linear) {
-    return ProcessOutputDevice89(untonemapped_ap1, output, outputdevice, cb_config);
-  }
-
-  return GenerateOutput(output.xyz, untonemapped_ap1, SV_Target, outputdevice, cb_config.ue_bluecorrection);
+  float3 tonemapped_bt709 = renodx::color::bt709::from::AP1(tonemapped_ap1);
+  return FinalizeLutbuilderOutput(untonemapped_ap1, tonemapped_bt709, cb_config, SV_Target, outputdevice);
 }
 
 // 1 SDR Lut
-
+// input: AP1 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
 float4 ProcessLutbuilder(float3 untonemapped_ap1, SamplerState lut_sampler, Texture2D<float4> lut_texture, UECbufferConfig cb_config, float4 SV_Target, uint outputdevice) {
-  float3 tonemapped;
+  float3 tonemapped_ap1;
+  ApplyFilmicToneMap(untonemapped_ap1, tonemapped_ap1, cb_config);
+  float3 tonemapped_bt709 = renodx::color::bt709::from::AP1(tonemapped_ap1);
 
-  ApplyFilmToneMapWithBlueCorrect(untonemapped_ap1, tonemapped, cb_config);
+  float3 lutted_bt709;
+  SampleLUTUpgradeToneMap(tonemapped_bt709, lut_sampler, lut_texture, lutted_bt709.r, lutted_bt709.g, lutted_bt709.b, cb_config);
 
-  float3 bt709_tonemapped = renodx::color::bt709::from::AP1(tonemapped);
-
-  float3 linear_output;
-  SampleLUTUpgradeToneMap(bt709_tonemapped, lut_sampler, lut_texture, linear_output.r, linear_output.g, linear_output.b, cb_config);
-
-  float3 scaled = cb_config.ue_colorscale.xyz * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * linear_output)) * linear_output) + cb_config.ue_mappingpolynomial.z);
-
-  float3 output = ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
-
-  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
-  if (is_linear) {
-    return ProcessOutputDevice89(untonemapped_ap1, output, outputdevice, cb_config);
-  }
-
-  return GenerateOutput(output.xyz, untonemapped_ap1, SV_Target, outputdevice, cb_config.ue_bluecorrection);
+  return FinalizeLutbuilderOutput(untonemapped_ap1, lutted_bt709, cb_config, SV_Target, outputdevice);
 }
 
 // 2 SDR Luts
-
+// input: AP1 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
 float4 ProcessLutbuilder(float3 untonemapped_ap1, SamplerState lut_sampler1, SamplerState lut_sampler2, Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, UECbufferConfig cb_config, float4 SV_Target, uint outputdevice) {
-  float3 tonemapped;
+  float3 tonemapped_ap1;
+  ApplyFilmicToneMap(untonemapped_ap1, tonemapped_ap1, cb_config);
+  float3 tonemapped_bt709 = renodx::color::bt709::from::AP1(tonemapped_ap1);
 
-  ApplyFilmToneMapWithBlueCorrect(untonemapped_ap1, tonemapped, cb_config);
+  float3 lutted_bt709;
+  Sample2LUTsUpgradeToneMap(tonemapped_bt709, lut_sampler1, lut_sampler2, lut_texture1, lut_texture2, lutted_bt709.r, lutted_bt709.g, lutted_bt709.b, cb_config);
 
-  float3 bt709_tonemapped = renodx::color::bt709::from::AP1(tonemapped);
-
-  float3 linear_output;
-  Sample2LUTsUpgradeToneMap(bt709_tonemapped, lut_sampler1, lut_sampler2, lut_texture1, lut_texture2, linear_output.r, linear_output.g, linear_output.b, cb_config);
-
-  float3 scaled = cb_config.ue_colorscale.xyz * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * linear_output)) * linear_output) + cb_config.ue_mappingpolynomial.z);
-
-  float3 output = ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
-
-  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
-  if (is_linear) {
-    return ProcessOutputDevice89(untonemapped_ap1, output, outputdevice, cb_config);
-  }
-
-  return GenerateOutput(output.xyz, untonemapped_ap1, SV_Target, outputdevice, cb_config.ue_bluecorrection);
+  return FinalizeLutbuilderOutput(untonemapped_ap1, lutted_bt709, cb_config, SV_Target, outputdevice);
 }
 
 // 3 SDR Luts
-
+// input: AP1 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
 float4 ProcessLutbuilder(float3 untonemapped_ap1, SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3, Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3, UECbufferConfig cb_config, float4 SV_Target, uint outputdevice) {
-  float3 tonemapped;
+  float3 tonemapped_ap1;
+  ApplyFilmicToneMap(untonemapped_ap1, tonemapped_ap1, cb_config);
+  float3 tonemapped_bt709 = renodx::color::bt709::from::AP1(tonemapped_ap1);
 
-  ApplyFilmToneMapWithBlueCorrect(untonemapped_ap1, tonemapped, cb_config);
+  float3 lutted_bt709;
+  Sample3LUTsUpgradeToneMap(tonemapped_bt709, lut_sampler1, lut_sampler2, lut_sampler3, lut_texture1, lut_texture2, lut_texture3, lutted_bt709.r, lutted_bt709.g, lutted_bt709.b, cb_config);
 
-  float3 bt709_tonemapped = renodx::color::bt709::from::AP1(tonemapped);
-
-  float3 linear_output;
-  Sample3LUTsUpgradeToneMap(bt709_tonemapped, lut_sampler1, lut_sampler2, lut_sampler3, lut_texture1, lut_texture2, lut_texture3, linear_output.r, linear_output.g, linear_output.b, cb_config);
-
-  float3 scaled = cb_config.ue_colorscale.xyz * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * linear_output)) * linear_output) + cb_config.ue_mappingpolynomial.z);
-
-  float3 output = ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
-
-  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
-  if (is_linear) {
-    return ProcessOutputDevice89(untonemapped_ap1, output, outputdevice, cb_config);
-  }
-
-  return GenerateOutput(output.xyz, untonemapped_ap1, SV_Target, outputdevice, cb_config.ue_bluecorrection);
+  return FinalizeLutbuilderOutput(untonemapped_ap1, lutted_bt709, cb_config, SV_Target, outputdevice);
 }
 
 // 4 SDR luts
-
+// input: AP1 linear
+// output: linear BT.709, PQ-encoded BT.2020, or sRGB-encoded BT.709
 float4 ProcessLutbuilder(float3 untonemapped_ap1, SamplerState lut_sampler1, SamplerState lut_sampler2, SamplerState lut_sampler3, SamplerState lut_sampler4, Texture2D<float4> lut_texture1, Texture2D<float4> lut_texture2, Texture2D<float4> lut_texture3, Texture2D<float4> lut_texture4, UECbufferConfig cb_config, float4 SV_Target, uint outputdevice) {
-  float3 tonemapped;
+  float3 tonemapped_ap1;
+  ApplyFilmicToneMap(untonemapped_ap1, tonemapped_ap1, cb_config);
+  float3 tonemapped_bt709 = renodx::color::bt709::from::AP1(tonemapped_ap1);
 
-  ApplyFilmToneMapWithBlueCorrect(untonemapped_ap1, tonemapped, cb_config);
+  float3 lutted_bt709;
+  Sample4LUTsUpgradeToneMap(tonemapped_bt709, lut_sampler1, lut_sampler2, lut_sampler3, lut_sampler4, lut_texture1, lut_texture2, lut_texture3, lut_texture4, lutted_bt709.r, lutted_bt709.g, lutted_bt709.b, cb_config);
 
-  float3 bt709_tonemapped = renodx::color::bt709::from::AP1(tonemapped);
-
-  float3 linear_output;
-  Sample4LUTsUpgradeToneMap(bt709_tonemapped, lut_sampler1, lut_sampler2, lut_sampler3, lut_sampler4, lut_texture1, lut_texture2, lut_texture3, lut_texture4, linear_output.r, linear_output.g, linear_output.b, cb_config);
-
-  float3 scaled = cb_config.ue_colorscale.xyz * (((cb_config.ue_mappingpolynomial.y + (cb_config.ue_mappingpolynomial.x * linear_output)) * linear_output) + cb_config.ue_mappingpolynomial.z);
-
-  float3 output = ((cb_config.ue_overlaycolor.xyz - scaled) * cb_config.ue_overlaycolor.w) + scaled;
-
-  bool is_linear = (outputdevice == 8u || outputdevice == 9u);
-  if (is_linear) {
-    return ProcessOutputDevice89(untonemapped_ap1, output, outputdevice, cb_config);
-  }
-
-  return GenerateOutput(output.xyz, untonemapped_ap1, SV_Target, outputdevice, cb_config.ue_bluecorrection);
+  return FinalizeLutbuilderOutput(untonemapped_ap1, lutted_bt709, cb_config, SV_Target, outputdevice);
 }

--- a/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0x0A2AEAEA.cs_6_6.hlsl
+++ b/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0x0A2AEAEA.cs_6_6.hlsl
@@ -1,0 +1,1709 @@
+// From Halo Campaign Evolved
+
+#include "../lutbuilderoutput.hlsli"
+
+RWTexture3D<float4> u0 : register(u0);
+
+cbuffer cb0 : register(b0) {
+  float cb0_008x : packoffset(c008.x);
+  float cb0_008y : packoffset(c008.y);
+  float cb0_008z : packoffset(c008.z);
+  float cb0_008w : packoffset(c008.w);
+  float cb0_009x : packoffset(c009.x);
+  float cb0_010x : packoffset(c010.x);
+  float cb0_010y : packoffset(c010.y);
+  float cb0_010z : packoffset(c010.z);
+  float cb0_010w : packoffset(c010.w);
+  float cb0_011x : packoffset(c011.x);
+  float cb0_011y : packoffset(c011.y);
+  float cb0_011z : packoffset(c011.z);
+  float cb0_011w : packoffset(c011.w);
+  float cb0_012x : packoffset(c012.x);
+  float cb0_012y : packoffset(c012.y);
+  float cb0_012z : packoffset(c012.z);
+  float cb0_012w : packoffset(c012.w);
+  float cb0_013x : packoffset(c013.x);
+  float cb0_013y : packoffset(c013.y);
+  float cb0_013z : packoffset(c013.z);
+  float cb0_013w : packoffset(c013.w);
+  float cb0_014x : packoffset(c014.x);
+  float cb0_014y : packoffset(c014.y);
+  float cb0_014z : packoffset(c014.z);
+  float cb0_015x : packoffset(c015.x);
+  float cb0_015y : packoffset(c015.y);
+  float cb0_015z : packoffset(c015.z);
+  float cb0_015w : packoffset(c015.w);
+  float cb0_016x : packoffset(c016.x);
+  float cb0_016y : packoffset(c016.y);
+  float cb0_016z : packoffset(c016.z);
+  float cb0_016w : packoffset(c016.w);
+  float cb0_017x : packoffset(c017.x);
+  float cb0_017y : packoffset(c017.y);
+  float cb0_017z : packoffset(c017.z);
+  float cb0_017w : packoffset(c017.w);
+  float cb0_018x : packoffset(c018.x);
+  float cb0_018y : packoffset(c018.y);
+  float cb0_018z : packoffset(c018.z);
+  float cb0_018w : packoffset(c018.w);
+  float cb0_019x : packoffset(c019.x);
+  float cb0_019y : packoffset(c019.y);
+  float cb0_019z : packoffset(c019.z);
+  float cb0_019w : packoffset(c019.w);
+  float cb0_020x : packoffset(c020.x);
+  float cb0_020y : packoffset(c020.y);
+  float cb0_020z : packoffset(c020.z);
+  float cb0_020w : packoffset(c020.w);
+  float cb0_021x : packoffset(c021.x);
+  float cb0_021y : packoffset(c021.y);
+  float cb0_021z : packoffset(c021.z);
+  float cb0_021w : packoffset(c021.w);
+  float cb0_022x : packoffset(c022.x);
+  float cb0_022y : packoffset(c022.y);
+  float cb0_022z : packoffset(c022.z);
+  float cb0_022w : packoffset(c022.w);
+  float cb0_023x : packoffset(c023.x);
+  float cb0_023y : packoffset(c023.y);
+  float cb0_023z : packoffset(c023.z);
+  float cb0_023w : packoffset(c023.w);
+  float cb0_024x : packoffset(c024.x);
+  float cb0_024y : packoffset(c024.y);
+  float cb0_024z : packoffset(c024.z);
+  float cb0_024w : packoffset(c024.w);
+  float cb0_025x : packoffset(c025.x);
+  float cb0_025y : packoffset(c025.y);
+  float cb0_025z : packoffset(c025.z);
+  float cb0_025w : packoffset(c025.w);
+  float cb0_026x : packoffset(c026.x);
+  float cb0_026y : packoffset(c026.y);
+  float cb0_026z : packoffset(c026.z);
+  float cb0_026w : packoffset(c026.w);
+  float cb0_027x : packoffset(c027.x);
+  float cb0_027y : packoffset(c027.y);
+  float cb0_027z : packoffset(c027.z);
+  float cb0_027w : packoffset(c027.w);
+  float cb0_028x : packoffset(c028.x);
+  float cb0_028y : packoffset(c028.y);
+  float cb0_028z : packoffset(c028.z);
+  float cb0_028w : packoffset(c028.w);
+  float cb0_029x : packoffset(c029.x);
+  float cb0_029y : packoffset(c029.y);
+  float cb0_029z : packoffset(c029.z);
+  float cb0_029w : packoffset(c029.w);
+  float cb0_030x : packoffset(c030.x);
+  float cb0_030y : packoffset(c030.y);
+  float cb0_030z : packoffset(c030.z);
+  float cb0_030w : packoffset(c030.w);
+  float cb0_031x : packoffset(c031.x);
+  float cb0_031y : packoffset(c031.y);
+  float cb0_031z : packoffset(c031.z);
+  float cb0_031w : packoffset(c031.w);
+  float cb0_032x : packoffset(c032.x);
+  float cb0_032y : packoffset(c032.y);
+  float cb0_032z : packoffset(c032.z);
+  float cb0_032w : packoffset(c032.w);
+  float cb0_033x : packoffset(c033.x);
+  float cb0_033y : packoffset(c033.y);
+  float cb0_033z : packoffset(c033.z);
+  float cb0_033w : packoffset(c033.w);
+  float cb0_034x : packoffset(c034.x);
+  float cb0_034y : packoffset(c034.y);
+  float cb0_034z : packoffset(c034.z);
+  float cb0_034w : packoffset(c034.w);
+  float cb0_035x : packoffset(c035.x);
+  float cb0_035y : packoffset(c035.y);
+  float cb0_035z : packoffset(c035.z);
+  float cb0_035w : packoffset(c035.w);
+  float cb0_036x : packoffset(c036.x);
+  float cb0_036y : packoffset(c036.y);
+  float cb0_036z : packoffset(c036.z);
+  float cb0_036w : packoffset(c036.w);
+  float cb0_037x : packoffset(c037.x);
+  float cb0_037y : packoffset(c037.y);
+  float cb0_037z : packoffset(c037.z);
+  float cb0_037w : packoffset(c037.w);
+  float cb0_038x : packoffset(c038.x);
+  float cb0_038y : packoffset(c038.y);
+  int cb0_038w : packoffset(c038.w);
+  float cb0_039x : packoffset(c039.x);
+  float cb0_039y : packoffset(c039.y);
+  float cb0_039z : packoffset(c039.z);
+  float cb0_040y : packoffset(c040.y);
+  float cb0_040z : packoffset(c040.z);
+  int cb0_040w : packoffset(c040.w);
+  int cb0_041x : packoffset(c041.x);
+  float cb0_042x : packoffset(c042.x);
+  float cb0_042y : packoffset(c042.y);
+};
+
+cbuffer cb1 : register(b1) {
+  float4 WorkingColorSpace_000[4] : packoffset(c000.x);
+  float4 WorkingColorSpace_064[4] : packoffset(c004.x);
+  float4 WorkingColorSpace_128[4] : packoffset(c008.x);
+  float4 WorkingColorSpace_192[4] : packoffset(c012.x);
+  float4 WorkingColorSpace_256[4] : packoffset(c016.x);
+  int WorkingColorSpace_320 : packoffset(c020.x);
+};
+
+// DXIL FirstbitHi: returns bit position counting from MSB (leading zeros count)
+uint firstbithigh_msb(int value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+uint firstbithigh_msb(uint value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+
+[numthreads(8, 8, 8)]
+void main(
+  uint3 SV_DispatchThreadID : SV_DispatchThreadID,
+  uint3 SV_GroupID : SV_GroupID,
+  uint3 SV_GroupThreadID : SV_GroupThreadID,
+  uint SV_GroupIndex : SV_GroupIndex
+) {
+  float _32;
+  float _37;
+  float _38;
+  float _39;
+  float _41;
+  float _61;
+  float _62;
+  float _63;
+  float _64;
+  float _65;
+  float _66;
+  float _67;
+  float _68;
+  float _69;
+  float _127;
+  float _128;
+  float _129;
+  float _177;
+  float _905;
+  float _938;
+  float _952;
+  float _1016;
+  float _1284;
+  float _1285;
+  float _1286;
+  float _1297;
+  float _1308;
+  float _1481;
+  float _1496;
+  float _1511;
+  float _1519;
+  float _1520;
+  float _1521;
+  float _1588;
+  float _1621;
+  float _1635;
+  float _1674;
+  float _1796;
+  float _1882;
+  float _1956;
+  float _2035;
+  float _2036;
+  float _2037;
+  float _2167;
+  float _2182;
+  float _2197;
+  float _2205;
+  float _2206;
+  float _2207;
+  float _2274;
+  float _2307;
+  float _2321;
+  float _2360;
+  float _2482;
+  float _2568;
+  float _2654;
+  float _2733;
+  float _2734;
+  float _2735;
+  float _2912;
+  float _2913;
+  float _2914;
+  bool _50;
+  float _80;
+  float _81;
+  float _82;
+  bool _156;
+  float _160;
+  float _191;
+  float _198;
+  float _201;
+  float _206;
+  float _207;
+  float _209;
+  bool _210;
+  float _219;
+  float _221;
+  float _228;
+  float _230;
+  float _232;
+  float _233;
+  float _236;
+  float _239;
+  float _244;
+  float _250;
+  float _251;
+  float _252;
+  float _253;
+  float _254;
+  float _255;
+  float _256;
+  float _257;
+  float _260;
+  float _261;
+  float _262;
+  float _265;
+  float _284;
+  float _285;
+  float _286;
+  float _287;
+  float _288;
+  float _289;
+  float _290;
+  float _291;
+  float _292;
+  float _295;
+  float _298;
+  float _301;
+  float _304;
+  float _307;
+  float _310;
+  float _313;
+  float _316;
+  float _319;
+  float _322;
+  float _325;
+  float _328;
+  float _331;
+  float _334;
+  float _337;
+  float _340;
+  float _343;
+  float _346;
+  float _376;
+  float _379;
+  float _382;
+  float _397;
+  float _400;
+  float _403;
+  float _404;
+  float _408;
+  float _409;
+  float _410;
+  float _422;
+  float _438;
+  float _439;
+  float _440;
+  float _441;
+  float _455;
+  float _469;
+  float _483;
+  float _497;
+  float _511;
+  float _515;
+  float _516;
+  float _517;
+  float _574;
+  float _578;
+  float _579;
+  float _588;
+  float _597;
+  float _606;
+  float _615;
+  float _624;
+  float _687;
+  float _691;
+  float _700;
+  float _709;
+  float _718;
+  float _727;
+  float _736;
+  float _794;
+  float _805;
+  float _807;
+  float _809;
+  float _845;
+  float _846;
+  float _847;
+  float _850;
+  float _853;
+  float _856;
+  float _860;
+  float _865;
+  float _878;
+  float _879;
+  float _880;
+  float _881;
+  float _885;
+  float _896;
+  float _906;
+  float _907;
+  float _908;
+  float _909;
+  float _916;
+  float _919;
+  float _921;
+  bool _924;
+  bool _925;
+  bool _926;
+  bool _927;
+  float _943;
+  float _956;
+  float _960;
+  float _966;
+  float _976;
+  float _977;
+  float _978;
+  float _979;
+  float _994;
+  float _996;
+  float _998;
+  float _1007;
+  float _1019;
+  float _1021;
+  float _1025;
+  float _1026;
+  float _1027;
+  float _1031;
+  float _1032;
+  float _1033;
+  float _1034;
+  float _1036;
+  float _1037;
+  float _1038;
+  float _1039;
+  float _1058;
+  float _1060;
+  float _1085;
+  float _1086;
+  float _1087;
+  float _1094;
+  float _1098;
+  float _1099;
+  float _1100;
+  bool _1101;
+  float _1105;
+  float _1106;
+  float _1107;
+  float _1126;
+  float _1127;
+  float _1128;
+  float _1129;
+  float _1149;
+  float _1150;
+  float _1151;
+  float _1167;
+  float _1168;
+  float _1169;
+  float _1179;
+  float _1180;
+  float _1181;
+  float _1207;
+  float _1208;
+  float _1209;
+  float _1216;
+  float _1217;
+  float _1218;
+  float _1219;
+  float _1220;
+  float _1221;
+  float _1228;
+  float _1229;
+  float _1230;
+  float _1242;
+  float _1243;
+  float _1244;
+  float _1267;
+  float _1270;
+  float _1273;
+  float _1335;
+  float _1338;
+  float _1341;
+  float _1351;
+  float _1352;
+  float _1353;
+  float _1429;
+  float _1430;
+  float _1431;
+  float _1434;
+  float _1437;
+  float _1440;
+  float _1443;
+  float _1446;
+  float _1449;
+  float _1451;
+  float _1461;
+  float _1462;
+  float _1464;
+  float _1466;
+  float _1469;
+  float _1484;
+  float _1499;
+  float _1537;
+  float _1538;
+  float _1539;
+  float _1543;
+  float _1548;
+  float _1561;
+  float _1562;
+  float _1563;
+  float _1564;
+  float _1568;
+  float _1579;
+  float _1589;
+  float _1590;
+  float _1591;
+  float _1592;
+  float _1599;
+  float _1602;
+  float _1604;
+  bool _1607;
+  bool _1608;
+  bool _1609;
+  bool _1610;
+  float _1626;
+  float _1641;
+  int _1642;
+  float _1644;
+  float _1645;
+  float _1646;
+  float _1683;
+  float _1684;
+  float _1685;
+  float _1698;
+  float _1699;
+  float _1700;
+  float _1701;
+  float _1724;
+  float _1725;
+  float _1726;
+  float _1727;
+  float _1734;
+  float _1735;
+  float _1743;
+  int _1744;
+  float _1746;
+  float _1748;
+  float _1751;
+  float _1756;
+  float _1765;
+  float _1773;
+  int _1774;
+  float _1776;
+  float _1778;
+  float _1781;
+  float _1786;
+  float _1812;
+  float _1813;
+  float _1820;
+  float _1821;
+  float _1829;
+  int _1830;
+  float _1832;
+  float _1834;
+  float _1837;
+  float _1842;
+  float _1851;
+  float _1859;
+  int _1860;
+  float _1862;
+  float _1864;
+  float _1867;
+  float _1872;
+  float _1886;
+  float _1887;
+  float _1894;
+  float _1895;
+  float _1903;
+  int _1904;
+  float _1906;
+  float _1908;
+  float _1911;
+  float _1916;
+  float _1925;
+  float _1933;
+  int _1934;
+  float _1936;
+  float _1938;
+  float _1941;
+  float _1946;
+  float _1960;
+  float _1961;
+  float _1963;
+  float _1965;
+  float _1968;
+  float _1971;
+  float _1974;
+  float _1987;
+  float _1988;
+  float _1989;
+  float _1992;
+  float _1995;
+  float _1998;
+  float _2020;
+  float _2021;
+  float _2022;
+  float _2047;
+  float _2048;
+  float _2049;
+  float _2115;
+  float _2116;
+  float _2117;
+  float _2120;
+  float _2123;
+  float _2126;
+  float _2129;
+  float _2132;
+  float _2135;
+  float _2137;
+  float _2147;
+  float _2148;
+  float _2150;
+  float _2152;
+  float _2155;
+  float _2170;
+  float _2185;
+  float _2223;
+  float _2224;
+  float _2225;
+  float _2229;
+  float _2234;
+  float _2247;
+  float _2248;
+  float _2249;
+  float _2250;
+  float _2254;
+  float _2265;
+  float _2275;
+  float _2276;
+  float _2277;
+  float _2278;
+  float _2285;
+  float _2288;
+  float _2290;
+  bool _2293;
+  bool _2294;
+  bool _2295;
+  bool _2296;
+  float _2312;
+  float _2327;
+  int _2328;
+  float _2330;
+  float _2331;
+  float _2332;
+  float _2369;
+  float _2370;
+  float _2371;
+  float _2384;
+  float _2385;
+  float _2386;
+  float _2387;
+  float _2410;
+  float _2411;
+  float _2412;
+  float _2413;
+  float _2420;
+  float _2421;
+  float _2429;
+  int _2430;
+  float _2432;
+  float _2434;
+  float _2437;
+  float _2442;
+  float _2451;
+  float _2459;
+  int _2460;
+  float _2462;
+  float _2464;
+  float _2467;
+  float _2472;
+  float _2498;
+  float _2499;
+  float _2506;
+  float _2507;
+  float _2515;
+  int _2516;
+  float _2518;
+  float _2520;
+  float _2523;
+  float _2528;
+  float _2537;
+  float _2545;
+  int _2546;
+  float _2548;
+  float _2550;
+  float _2553;
+  float _2558;
+  float _2584;
+  float _2585;
+  float _2592;
+  float _2593;
+  float _2601;
+  int _2602;
+  float _2604;
+  float _2606;
+  float _2609;
+  float _2614;
+  float _2623;
+  float _2631;
+  int _2632;
+  float _2634;
+  float _2636;
+  float _2639;
+  float _2644;
+  float _2658;
+  float _2659;
+  float _2661;
+  float _2663;
+  float _2666;
+  float _2669;
+  float _2672;
+  float _2685;
+  float _2686;
+  float _2687;
+  float _2690;
+  float _2693;
+  float _2696;
+  float _2718;
+  float _2719;
+  float _2720;
+  float _2745;
+  float _2746;
+  float _2747;
+  float _2792;
+  float _2795;
+  float _2798;
+  float _2817;
+  float _2818;
+  float _2819;
+  float _2866;
+  float _2869;
+  float _2872;
+  float _2885;
+  float _2888;
+  float _2891;
+  float _9[6];
+  float _10[6];
+  float _11[6];
+  float _12[6];
+  float _13[6];
+  float _14[6];
+  float _15[6];
+  float _16[6];
+  float _17[6];
+  float _18[6];
+  float _19[6];
+  float _20[6];
+  _32 = 0.5f / cb0_035x;
+  _37 = cb0_035x + -1.0f;
+  _38 = (cb0_035x * ((cb0_042x * (((float)((uint)SV_DispatchThreadID.x)) + 0.5f)) - _32)) / _37;
+  _39 = (cb0_035x * ((cb0_042y * (((float)((uint)SV_DispatchThreadID.y)) + 0.5f)) - _32)) / _37;
+  _41 = ((float)((uint)SV_DispatchThreadID.z)) / _37;
+  if (!(cb0_041x == 1)) {
+    if (!(cb0_041x == 2)) {
+      if (!(cb0_041x == 3)) {
+        _50 = (cb0_041x == 4);
+        _61 = select(_50, 1.0f, 1.705051064491272f);
+        _62 = select(_50, 0.0f, -0.6217921376228333f);
+        _63 = select(_50, 0.0f, -0.0832589864730835f);
+        _64 = select(_50, 0.0f, -0.13025647401809692f);
+        _65 = select(_50, 1.0f, 1.140804648399353f);
+        _66 = select(_50, 0.0f, -0.010548308491706848f);
+        _67 = select(_50, 0.0f, -0.024003351107239723f);
+        _68 = select(_50, 0.0f, -0.1289689838886261f);
+        _69 = select(_50, 1.0f, 1.1529725790023804f);
+      } else {
+        _61 = 0.6954522132873535f;
+        _62 = 0.14067870378494263f;
+        _63 = 0.16386906802654266f;
+        _64 = 0.044794563204050064f;
+        _65 = 0.8596711158752441f;
+        _66 = 0.0955343171954155f;
+        _67 = -0.005525882821530104f;
+        _68 = 0.004025210160762072f;
+        _69 = 1.0015007257461548f;
+      }
+    } else {
+      _61 = 1.0258246660232544f;
+      _62 = -0.020053181797266006f;
+      _63 = -0.005771636962890625f;
+      _64 = -0.002234415616840124f;
+      _65 = 1.0045864582061768f;
+      _66 = -0.002352118492126465f;
+      _67 = -0.005013350863009691f;
+      _68 = -0.025290070101618767f;
+      _69 = 1.0303035974502563f;
+    }
+  } else {
+    _61 = 1.3792141675949097f;
+    _62 = -0.30886411666870117f;
+    _63 = -0.0703500509262085f;
+    _64 = -0.06933490186929703f;
+    _65 = 1.08229660987854f;
+    _66 = -0.012961871922016144f;
+    _67 = -0.0021590073592960835f;
+    _68 = -0.0454593189060688f;
+    _69 = 1.0476183891296387f;
+  }
+  [branch]
+  if ((uint)cb0_040w > (uint)2) {
+    _80 = (pow(_38, 0.012683313339948654f));
+    _81 = (pow(_39, 0.012683313339948654f));
+    _82 = (pow(_41, 0.012683313339948654f));
+    _127 = (exp2(log2(max(0.0f, (_80 + -0.8359375f)) / (18.8515625f - (_80 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+    _128 = (exp2(log2(max(0.0f, (_81 + -0.8359375f)) / (18.8515625f - (_81 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+    _129 = (exp2(log2(max(0.0f, (_82 + -0.8359375f)) / (18.8515625f - (_82 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+  } else {
+    _127 = ((exp2((_38 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+    _128 = ((exp2((_39 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+    _129 = ((exp2((_41 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+  }
+  _156 = (cb0_038w != 0);
+  _160 = 0.9994439482688904f / cb0_035y;
+  if (!(!((cb0_035y * 1.0005563497543335f) <= 7000.0f))) {
+    _177 = (((((2967800.0f - (_160 * 4607000064.0f)) * _160) + 99.11000061035156f) * _160) + 0.24406300485134125f);
+  } else {
+    _177 = (((((1901800.0f - (_160 * 2006400000.0f)) * _160) + 247.47999572753906f) * _160) + 0.23703999817371368f);
+  }
+  _191 = ((((cb0_035y * 1.2864121856637212e-07f) + 0.00015411825734190643f) * cb0_035y) + 0.8601177334785461f) / ((((cb0_035y * 7.081451371959702e-07f) + 0.0008424202096648514f) * cb0_035y) + 1.0f);
+  _198 = cb0_035y * cb0_035y;
+  _201 = ((((cb0_035y * 4.204816761443908e-08f) + 4.228062607580796e-05f) * cb0_035y) + 0.31739872694015503f) / ((1.0f - (cb0_035y * 2.8974181986995973e-05f)) + (_198 * 1.6145605741257896e-07f));
+  _206 = ((_191 * 2.0f) + 4.0f) - (_201 * 8.0f);
+  _207 = (_191 * 3.0f) / _206;
+  _209 = (_201 * 2.0f) / _206;
+  _210 = (cb0_035y < 4000.0f);
+  _219 = ((cb0_035y + 1189.6199951171875f) * cb0_035y) + 1412139.875f;
+  _221 = ((-1137581184.0f - (cb0_035y * 1916156.25f)) - (_198 * 1.5317699909210205f)) / (_219 * _219);
+  _228 = (6193636.0f - (cb0_035y * 179.45599365234375f)) + _198;
+  _230 = ((1974715392.0f - (cb0_035y * 705674.0f)) - (_198 * 308.60699462890625f)) / (_228 * _228);
+  _232 = rsqrt(dot(float2(_221, _230), float2(_221, _230)));
+  _233 = cb0_035z * 0.05000000074505806f;
+  _236 = ((_233 * _230) * _232) + _191;
+  _239 = _201 - ((_233 * _221) * _232);
+  _244 = (4.0f - (_239 * 8.0f)) + (_236 * 2.0f);
+  _250 = (((_236 * 3.0f) / _244) - _207) + select(_210, _207, _177);
+  _251 = (((_239 * 2.0f) / _244) - _209) + select(_210, _209, (((_177 * 2.869999885559082f) + -0.2750000059604645f) - ((_177 * _177) * 3.0f)));
+  _252 = select(_156, _250, 0.3127000033855438f);
+  _253 = select(_156, _251, 0.32899999618530273f);
+  _254 = select(_156, 0.3127000033855438f, _250);
+  _255 = select(_156, 0.32899999618530273f, _251);
+  _256 = max(_253, 1.000000013351432e-10f);
+  _257 = _252 / _256;
+  _260 = ((1.0f - _252) - _253) / _256;
+  _261 = max(_255, 1.000000013351432e-10f);
+  _262 = _254 / _261;
+  _265 = ((1.0f - _254) - _255) / _261;
+  _284 = mad(-0.16140000522136688f, _265, ((_262 * 0.8950999975204468f) + 0.266400009393692f)) / mad(-0.16140000522136688f, _260, ((_257 * 0.8950999975204468f) + 0.266400009393692f));
+  _285 = mad(0.03669999912381172f, _265, (1.7135000228881836f - (_262 * 0.7501999735832214f))) / mad(0.03669999912381172f, _260, (1.7135000228881836f - (_257 * 0.7501999735832214f)));
+  _286 = mad(1.0296000242233276f, _265, ((_262 * 0.03889999911189079f) + -0.06849999725818634f)) / mad(1.0296000242233276f, _260, ((_257 * 0.03889999911189079f) + -0.06849999725818634f));
+  _287 = mad(_285, -0.7501999735832214f, 0.0f);
+  _288 = mad(_285, 1.7135000228881836f, 0.0f);
+  _289 = mad(_285, 0.03669999912381172f, -0.0f);
+  _290 = mad(_286, 0.03889999911189079f, 0.0f);
+  _291 = mad(_286, -0.06849999725818634f, 0.0f);
+  _292 = mad(_286, 1.0296000242233276f, 0.0f);
+  _295 = mad(0.1599626988172531f, _290, mad(-0.1470542997121811f, _287, (_284 * 0.883457362651825f)));
+  _298 = mad(0.1599626988172531f, _291, mad(-0.1470542997121811f, _288, (_284 * 0.26293492317199707f)));
+  _301 = mad(0.1599626988172531f, _292, mad(-0.1470542997121811f, _289, (_284 * -0.15930065512657166f)));
+  _304 = mad(0.04929120093584061f, _290, mad(0.5183603167533875f, _287, (_284 * 0.38695648312568665f)));
+  _307 = mad(0.04929120093584061f, _291, mad(0.5183603167533875f, _288, (_284 * 0.11516613513231277f)));
+  _310 = mad(0.04929120093584061f, _292, mad(0.5183603167533875f, _289, (_284 * -0.0697740763425827f)));
+  _313 = mad(0.9684867262840271f, _290, mad(0.04004279896616936f, _287, (_284 * -0.007634039502590895f)));
+  _316 = mad(0.9684867262840271f, _291, mad(0.04004279896616936f, _288, (_284 * -0.0022720457054674625f)));
+  _319 = mad(0.9684867262840271f, _292, mad(0.04004279896616936f, _289, (_284 * 0.0013765322510153055f)));
+  _322 = mad(_301, (WorkingColorSpace_000[2].x), mad(_298, (WorkingColorSpace_000[1].x), (_295 * (WorkingColorSpace_000[0].x))));
+  _325 = mad(_301, (WorkingColorSpace_000[2].y), mad(_298, (WorkingColorSpace_000[1].y), (_295 * (WorkingColorSpace_000[0].y))));
+  _328 = mad(_301, (WorkingColorSpace_000[2].z), mad(_298, (WorkingColorSpace_000[1].z), (_295 * (WorkingColorSpace_000[0].z))));
+  _331 = mad(_310, (WorkingColorSpace_000[2].x), mad(_307, (WorkingColorSpace_000[1].x), (_304 * (WorkingColorSpace_000[0].x))));
+  _334 = mad(_310, (WorkingColorSpace_000[2].y), mad(_307, (WorkingColorSpace_000[1].y), (_304 * (WorkingColorSpace_000[0].y))));
+  _337 = mad(_310, (WorkingColorSpace_000[2].z), mad(_307, (WorkingColorSpace_000[1].z), (_304 * (WorkingColorSpace_000[0].z))));
+  _340 = mad(_319, (WorkingColorSpace_000[2].x), mad(_316, (WorkingColorSpace_000[1].x), (_313 * (WorkingColorSpace_000[0].x))));
+  _343 = mad(_319, (WorkingColorSpace_000[2].y), mad(_316, (WorkingColorSpace_000[1].y), (_313 * (WorkingColorSpace_000[0].y))));
+  _346 = mad(_319, (WorkingColorSpace_000[2].z), mad(_316, (WorkingColorSpace_000[1].z), (_313 * (WorkingColorSpace_000[0].z))));
+  _376 = mad(mad((WorkingColorSpace_064[0].z), _346, mad((WorkingColorSpace_064[0].y), _337, (_328 * (WorkingColorSpace_064[0].x)))), _129, mad(mad((WorkingColorSpace_064[0].z), _343, mad((WorkingColorSpace_064[0].y), _334, (_325 * (WorkingColorSpace_064[0].x)))), _128, (mad((WorkingColorSpace_064[0].z), _340, mad((WorkingColorSpace_064[0].y), _331, (_322 * (WorkingColorSpace_064[0].x)))) * _127)));
+  _379 = mad(mad((WorkingColorSpace_064[1].z), _346, mad((WorkingColorSpace_064[1].y), _337, (_328 * (WorkingColorSpace_064[1].x)))), _129, mad(mad((WorkingColorSpace_064[1].z), _343, mad((WorkingColorSpace_064[1].y), _334, (_325 * (WorkingColorSpace_064[1].x)))), _128, (mad((WorkingColorSpace_064[1].z), _340, mad((WorkingColorSpace_064[1].y), _331, (_322 * (WorkingColorSpace_064[1].x)))) * _127)));
+  _382 = mad(mad((WorkingColorSpace_064[2].z), _346, mad((WorkingColorSpace_064[2].y), _337, (_328 * (WorkingColorSpace_064[2].x)))), _129, mad(mad((WorkingColorSpace_064[2].z), _343, mad((WorkingColorSpace_064[2].y), _334, (_325 * (WorkingColorSpace_064[2].x)))), _128, (mad((WorkingColorSpace_064[2].z), _340, mad((WorkingColorSpace_064[2].y), _331, (_322 * (WorkingColorSpace_064[2].x)))) * _127)));
+  _397 = mad((WorkingColorSpace_128[0].z), _382, mad((WorkingColorSpace_128[0].y), _379, ((WorkingColorSpace_128[0].x) * _376)));
+  _400 = mad((WorkingColorSpace_128[1].z), _382, mad((WorkingColorSpace_128[1].y), _379, ((WorkingColorSpace_128[1].x) * _376)));
+  _403 = mad((WorkingColorSpace_128[2].z), _382, mad((WorkingColorSpace_128[2].y), _379, ((WorkingColorSpace_128[2].x) * _376)));
+  _404 = dot(float3(_397, _400, _403), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _408 = (_397 / _404) + -1.0f;
+  _409 = (_400 / _404) + -1.0f;
+  _410 = (_403 / _404) + -1.0f;
+  // ExpandGamut set to 0
+  _422 = (1.0f - exp2(((_404 * _404) * -4.0f) * 0.f)) * (1.0f - exp2(dot(float3(_408, _409, _410), float3(_408, _409, _410)) * -4.0f));
+  _438 = ((mad(-0.06368321925401688f, _403, mad(-0.3292922377586365f, _400, (_397 * 1.3704125881195068f))) - _397) * _422) + _397;
+  _439 = ((mad(-0.010861365124583244f, _403, mad(1.0970927476882935f, _400, (_397 * -0.08343357592821121f))) - _400) * _422) + _400;
+  _440 = ((mad(1.2036951780319214f, _403, mad(-0.09862580895423889f, _400, (_397 * -0.02579331398010254f))) - _403) * _422) + _403;
+  _441 = dot(float3(_438, _439, _440), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _455 = cb0_019w + cb0_024w;
+  _469 = cb0_018w * cb0_023w;
+  _483 = cb0_017w * cb0_022w;
+  _497 = cb0_016w * cb0_021w;
+  _511 = cb0_015w * cb0_020w;
+  _515 = _438 - _441;
+  _516 = _439 - _441;
+  _517 = _440 - _441;
+  _574 = saturate(_441 / cb0_035w);
+  _578 = (_574 * _574) * (3.0f - (_574 * 2.0f));
+  _579 = 1.0f - _578;
+  _588 = cb0_019w + cb0_034w;
+  _597 = cb0_018w * cb0_033w;
+  _606 = cb0_017w * cb0_032w;
+  _615 = cb0_016w * cb0_031w;
+  _624 = cb0_015w * cb0_030w;
+  _687 = saturate((_441 - cb0_036x) / (cb0_036y - cb0_036x));
+  _691 = (_687 * _687) * (3.0f - (_687 * 2.0f));
+  _700 = cb0_019w + cb0_029w;
+  _709 = cb0_018w * cb0_028w;
+  _718 = cb0_017w * cb0_027w;
+  _727 = cb0_016w * cb0_026w;
+  _736 = cb0_015w * cb0_025w;
+  _794 = _578 - _691;
+  _805 = ((_691 * (((cb0_019x + cb0_034x) + _588) + (((cb0_018x * cb0_033x) * _597) * exp2(log2(exp2(((cb0_016x * cb0_031x) * _615) * log2(max(0.0f, ((((cb0_015x * cb0_030x) * _624) * _515) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_032x) * _606)))))) + (_579 * (((cb0_019x + cb0_024x) + _455) + (((cb0_018x * cb0_023x) * _469) * exp2(log2(exp2(((cb0_016x * cb0_021x) * _497) * log2(max(0.0f, ((((cb0_015x * cb0_020x) * _511) * _515) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_022x) * _483))))))) + ((((cb0_019x + cb0_029x) + _700) + (((cb0_018x * cb0_028x) * _709) * exp2(log2(exp2(((cb0_016x * cb0_026x) * _727) * log2(max(0.0f, ((((cb0_015x * cb0_025x) * _736) * _515) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_027x) * _718))))) * _794);
+  _807 = ((_691 * (((cb0_019y + cb0_034y) + _588) + (((cb0_018y * cb0_033y) * _597) * exp2(log2(exp2(((cb0_016y * cb0_031y) * _615) * log2(max(0.0f, ((((cb0_015y * cb0_030y) * _624) * _516) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_032y) * _606)))))) + (_579 * (((cb0_019y + cb0_024y) + _455) + (((cb0_018y * cb0_023y) * _469) * exp2(log2(exp2(((cb0_016y * cb0_021y) * _497) * log2(max(0.0f, ((((cb0_015y * cb0_020y) * _511) * _516) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_022y) * _483))))))) + ((((cb0_019y + cb0_029y) + _700) + (((cb0_018y * cb0_028y) * _709) * exp2(log2(exp2(((cb0_016y * cb0_026y) * _727) * log2(max(0.0f, ((((cb0_015y * cb0_025y) * _736) * _516) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_027y) * _718))))) * _794);
+  _809 = ((_691 * (((cb0_019z + cb0_034z) + _588) + (((cb0_018z * cb0_033z) * _597) * exp2(log2(exp2(((cb0_016z * cb0_031z) * _615) * log2(max(0.0f, ((((cb0_015z * cb0_030z) * _624) * _517) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_032z) * _606)))))) + (_579 * (((cb0_019z + cb0_024z) + _455) + (((cb0_018z * cb0_023z) * _469) * exp2(log2(exp2(((cb0_016z * cb0_021z) * _497) * log2(max(0.0f, ((((cb0_015z * cb0_020z) * _511) * _517) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_022z) * _483))))))) + ((((cb0_019z + cb0_029z) + _700) + (((cb0_018z * cb0_028z) * _709) * exp2(log2(exp2(((cb0_016z * cb0_026z) * _727) * log2(max(0.0f, ((((cb0_015z * cb0_025z) * _736) * _517) + _441)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_027z) * _718))))) * _794);
+  UECbufferConfig cb_config = CreateCbufferConfig();
+  cb_config.ue_filmblackclip = cb0_038x;
+  cb_config.ue_filmtoe = cb0_037z;
+  cb_config.ue_filmshoulder = cb0_037w;
+  cb_config.ue_filmslope = cb0_037y;
+  cb_config.ue_filmwhiteclip = cb0_038y;
+  cb_config.ue_tonecurveammount = cb0_037x;
+  cb_config.ue_mappingpolynomial = float3(cb0_039x, cb0_039y, cb0_039z);
+  cb_config.ue_overlaycolor = float4(cb0_013x, cb0_013y, cb0_013z, cb0_013w);
+  cb_config.ue_bluecorrection = cb0_036z;
+  cb_config.ue_colorscale = float3(cb0_014x, cb0_014y, cb0_014z);
+
+  float4 output = ProcessLutbuilder(float3(_805, _807, _809), cb_config, u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))], cb0_040w);
+  u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))] = output;
+  return;
+
+  _845 = ((mad(0.061360642313957214f, _809, mad(-4.540197551250458e-09f, _807, (_805 * 0.9386394023895264f))) - _805) * cb0_036z) + _805;
+  _846 = ((mad(0.169205904006958f, _809, mad(0.8307942152023315f, _807, (_805 * 6.775371730327606e-08f))) - _807) * cb0_036z) + _807;
+  _847 = (mad(-2.3283064365386963e-10f, _807, (_805 * -9.313225746154785e-10f)) * cb0_036z) + _809;
+  _850 = mad(0.16386905312538147f, _847, mad(0.14067868888378143f, _846, (_845 * 0.6954522132873535f)));
+  _853 = mad(0.0955343246459961f, _847, mad(0.8596711158752441f, _846, (_845 * 0.044794581830501556f)));
+  _856 = mad(1.0015007257461548f, _847, mad(0.004025210160762072f, _846, (_845 * -0.005525882821530104f)));
+  _860 = max(max(_850, _853), _856);
+  _865 = (max(_860, 1.000000013351432e-10f) - max(min(min(_850, _853), _856), 1.000000013351432e-10f)) / max(_860, 0.009999999776482582f);
+  _878 = ((_853 + _850) + _856) + (sqrt((((_856 - _853) * _856) + ((_853 - _850) * _853)) + ((_850 - _856) * _850)) * 1.75f);
+  _879 = _878 * 0.3333333432674408f;
+  _880 = _865 + -0.4000000059604645f;
+  _881 = _880 * 5.0f;
+  _885 = max((1.0f - abs(_880 * 2.5f)), 0.0f);
+  _896 = ((float((int)(((int)(uint)((int)(_881 > 0.0f))) - ((int)(uint)((int)(_881 < 0.0f))))) * (1.0f - (_885 * _885))) + 1.0f) * 0.02500000037252903f;
+  if (!(_879 <= 0.0533333346247673f)) {
+    if (!(_879 >= 0.1599999964237213f)) {
+      _905 = (((0.23999999463558197f / _878) + -0.5f) * _896);
+    } else {
+      _905 = 0.0f;
+    }
+  } else {
+    _905 = _896;
+  }
+  _906 = _905 + 1.0f;
+  _907 = _906 * _850;
+  _908 = _906 * _853;
+  _909 = _906 * _856;
+  if (!((_907 == _908) && (_908 == _909))) {
+    _916 = ((_907 * 2.0f) - _908) - _909;
+    _919 = ((_853 - _856) * 1.7320507764816284f) * _906;
+    _921 = atan(_919 / _916);
+    _924 = (_916 < 0.0f);
+    _925 = (_916 == 0.0f);
+    _926 = (_919 >= 0.0f);
+    _927 = (_919 < 0.0f);
+    _938 = select((_926 && _925), 90.0f, select((_927 && _925), -90.0f, (select((_927 && _924), (_921 + -3.1415927410125732f), select((_926 && _924), (_921 + 3.1415927410125732f), _921)) * 57.2957763671875f)));
+  } else {
+    _938 = 0.0f;
+  }
+  _943 = min(max(select((_938 < 0.0f), (_938 + 360.0f), _938), 0.0f), 360.0f);
+  if (_943 < -180.0f) {
+    _952 = (_943 + 360.0f);
+  } else {
+    if (_943 > 180.0f) {
+      _952 = (_943 + -360.0f);
+    } else {
+      _952 = _943;
+    }
+  }
+  _956 = saturate(1.0f - abs(_952 * 0.014814814552664757f));
+  _960 = (_956 * _956) * (3.0f - (_956 * 2.0f));
+  _966 = ((_960 * _960) * ((_865 * 0.18000000715255737f) * (0.029999999329447746f - _907))) + _907;
+  _976 = max(0.0f, mad(-0.21492856740951538f, _909, mad(-0.2365107536315918f, _908, (_966 * 1.4514392614364624f))));
+  _977 = max(0.0f, mad(-0.09967592358589172f, _909, mad(1.17622971534729f, _908, (_966 * -0.07655377686023712f))));
+  _978 = max(0.0f, mad(0.9977163076400757f, _909, mad(-0.006032449658960104f, _908, (_966 * 0.008316148072481155f))));
+  _979 = dot(float3(_976, _977, _978), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _994 = (cb0_038x + 1.0f) - cb0_037z;
+  _996 = cb0_038y + 1.0f;
+  _998 = _996 - cb0_037w;
+  if (cb0_037z > 0.800000011920929f) {
+    _1016 = (((0.8199999928474426f - cb0_037z) / cb0_037y) + -0.7447274923324585f);
+  } else {
+    _1007 = (cb0_038x + 0.18000000715255737f) / _994;
+    _1016 = (-0.7447274923324585f - ((log2(_1007 / (2.0f - _1007)) * 0.3465735912322998f) * (_994 / cb0_037y)));
+  }
+  _1019 = ((1.0f - cb0_037z) / cb0_037y) - _1016;
+  _1021 = (cb0_037w / cb0_037y) - _1019;
+  _1025 = log2(lerp(_979, _976, 0.9599999785423279f)) * 0.3010300099849701f;
+  _1026 = log2(lerp(_979, _977, 0.9599999785423279f)) * 0.3010300099849701f;
+  _1027 = log2(lerp(_979, _978, 0.9599999785423279f)) * 0.3010300099849701f;
+  _1031 = cb0_037y * (_1025 + _1019);
+  _1032 = cb0_037y * (_1026 + _1019);
+  _1033 = cb0_037y * (_1027 + _1019);
+  _1034 = _994 * 2.0f;
+  _1036 = (cb0_037y * -2.0f) / _994;
+  _1037 = _1025 - _1016;
+  _1038 = _1026 - _1016;
+  _1039 = _1027 - _1016;
+  _1058 = _998 * 2.0f;
+  _1060 = (cb0_037y * 2.0f) / _998;
+  _1085 = select((_1025 < _1016), ((_1034 / (exp2((_1037 * 1.4426950216293335f) * _1036) + 1.0f)) - cb0_038x), _1031);
+  _1086 = select((_1026 < _1016), ((_1034 / (exp2((_1038 * 1.4426950216293335f) * _1036) + 1.0f)) - cb0_038x), _1032);
+  _1087 = select((_1027 < _1016), ((_1034 / (exp2((_1039 * 1.4426950216293335f) * _1036) + 1.0f)) - cb0_038x), _1033);
+  _1094 = _1021 - _1016;
+  _1098 = saturate(_1037 / _1094);
+  _1099 = saturate(_1038 / _1094);
+  _1100 = saturate(_1039 / _1094);
+  _1101 = (_1021 < _1016);
+  _1105 = select(_1101, (1.0f - _1098), _1098);
+  _1106 = select(_1101, (1.0f - _1099), _1099);
+  _1107 = select(_1101, (1.0f - _1100), _1100);
+  _1126 = (((_1105 * _1105) * (select((_1025 > _1021), (_996 - (_1058 / (exp2(((_1025 - _1021) * 1.4426950216293335f) * _1060) + 1.0f))), _1031) - _1085)) * (3.0f - (_1105 * 2.0f))) + _1085;
+  _1127 = (((_1106 * _1106) * (select((_1026 > _1021), (_996 - (_1058 / (exp2(((_1026 - _1021) * 1.4426950216293335f) * _1060) + 1.0f))), _1032) - _1086)) * (3.0f - (_1106 * 2.0f))) + _1086;
+  _1128 = (((_1107 * _1107) * (select((_1027 > _1021), (_996 - (_1058 / (exp2(((_1027 - _1021) * 1.4426950216293335f) * _1060) + 1.0f))), _1033) - _1087)) * (3.0f - (_1107 * 2.0f))) + _1087;
+  _1129 = dot(float3(_1126, _1127, _1128), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _1149 = (cb0_037x * (max(0.0f, (lerp(_1129, _1126, 0.9300000071525574f))) - _845)) + _845;
+  _1150 = (cb0_037x * (max(0.0f, (lerp(_1129, _1127, 0.9300000071525574f))) - _846)) + _846;
+  _1151 = (cb0_037x * (max(0.0f, (lerp(_1129, _1128, 0.9300000071525574f))) - _847)) + _847;
+  _1167 = ((mad(-0.06537103652954102f, _1151, mad(1.451815478503704e-06f, _1150, (_1149 * 1.065374732017517f))) - _1149) * cb0_036z) + _1149;
+  _1168 = ((mad(-0.20366770029067993f, _1151, mad(1.2036634683609009f, _1150, (_1149 * -2.57161445915699e-07f))) - _1150) * cb0_036z) + _1150;
+  _1169 = ((mad(0.9999996423721313f, _1151, mad(2.0954757928848267e-08f, _1150, (_1149 * 1.862645149230957e-08f))) - _1151) * cb0_036z) + _1151;
+  _1179 = max(0.0f, mad((WorkingColorSpace_192[0].z), _1169, mad((WorkingColorSpace_192[0].y), _1168, ((WorkingColorSpace_192[0].x) * _1167))));
+  _1180 = max(0.0f, mad((WorkingColorSpace_192[1].z), _1169, mad((WorkingColorSpace_192[1].y), _1168, ((WorkingColorSpace_192[1].x) * _1167))));
+  _1181 = max(0.0f, mad((WorkingColorSpace_192[2].z), _1169, mad((WorkingColorSpace_192[2].y), _1168, ((WorkingColorSpace_192[2].x) * _1167))));
+  _1207 = cb0_014x * (((cb0_039y + (cb0_039x * _1179)) * _1179) + cb0_039z);
+  _1208 = cb0_014y * (((cb0_039y + (cb0_039x * _1180)) * _1180) + cb0_039z);
+  _1209 = cb0_014z * (((cb0_039y + (cb0_039x * _1181)) * _1181) + cb0_039z);
+  _1216 = ((cb0_013x - _1207) * cb0_013w) + _1207;
+  _1217 = ((cb0_013y - _1208) * cb0_013w) + _1208;
+  _1218 = ((cb0_013z - _1209) * cb0_013w) + _1209;
+  _1219 = cb0_014x * mad((WorkingColorSpace_192[0].z), _809, mad((WorkingColorSpace_192[0].y), _807, (_805 * (WorkingColorSpace_192[0].x))));
+  _1220 = cb0_014y * mad((WorkingColorSpace_192[1].z), _809, mad((WorkingColorSpace_192[1].y), _807, ((WorkingColorSpace_192[1].x) * _805)));
+  _1221 = cb0_014z * mad((WorkingColorSpace_192[2].z), _809, mad((WorkingColorSpace_192[2].y), _807, ((WorkingColorSpace_192[2].x) * _805)));
+  _1228 = ((cb0_013x - _1219) * cb0_013w) + _1219;
+  _1229 = ((cb0_013y - _1220) * cb0_013w) + _1220;
+  _1230 = ((cb0_013z - _1221) * cb0_013w) + _1221;
+  _1242 = exp2(log2(max(0.0f, _1216)) * cb0_040y);
+  _1243 = exp2(log2(max(0.0f, _1217)) * cb0_040y);
+  _1244 = exp2(log2(max(0.0f, _1218)) * cb0_040y);
+  [branch]
+  if (cb0_040w == 0) {
+    do {
+      _1284 = _1242;
+      _1285 = _1243;
+      _1286 = _1244;
+      if (WorkingColorSpace_320 == 0) {
+        _1267 = mad((WorkingColorSpace_128[0].z), _1244, mad((WorkingColorSpace_128[0].y), _1243, ((WorkingColorSpace_128[0].x) * _1242)));
+        _1270 = mad((WorkingColorSpace_128[1].z), _1244, mad((WorkingColorSpace_128[1].y), _1243, ((WorkingColorSpace_128[1].x) * _1242)));
+        _1273 = mad((WorkingColorSpace_128[2].z), _1244, mad((WorkingColorSpace_128[2].y), _1243, ((WorkingColorSpace_128[2].x) * _1242)));
+        _1284 = mad(_63, _1273, mad(_62, _1270, (_1267 * _61)));
+        _1285 = mad(_66, _1273, mad(_65, _1270, (_1267 * _64)));
+        _1286 = mad(_69, _1273, mad(_68, _1270, (_1267 * _67)));
+      }
+      do {
+        if (_1284 < 0.0031306699384003878f) {
+          _1297 = (_1284 * 12.920000076293945f);
+        } else {
+          _1297 = (((pow(_1284, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+        }
+        do {
+          if (_1285 < 0.0031306699384003878f) {
+            _1308 = (_1285 * 12.920000076293945f);
+          } else {
+            _1308 = (((pow(_1285, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+          }
+          if (_1286 < 0.0031306699384003878f) {
+            _2912 = _1297;
+            _2913 = _1308;
+            _2914 = (_1286 * 12.920000076293945f);
+          } else {
+            _2912 = _1297;
+            _2913 = _1308;
+            _2914 = (((pow(_1286, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+          }
+        } while (false);
+      } while (false);
+    } while (false);
+  } else {
+    if (cb0_040w == 1) {
+      _1335 = mad((WorkingColorSpace_128[0].z), _1244, mad((WorkingColorSpace_128[0].y), _1243, ((WorkingColorSpace_128[0].x) * _1242)));
+      _1338 = mad((WorkingColorSpace_128[1].z), _1244, mad((WorkingColorSpace_128[1].y), _1243, ((WorkingColorSpace_128[1].x) * _1242)));
+      _1341 = mad((WorkingColorSpace_128[2].z), _1244, mad((WorkingColorSpace_128[2].y), _1243, ((WorkingColorSpace_128[2].x) * _1242)));
+      _1351 = max(6.103519990574569e-05f, mad(_63, _1341, mad(_62, _1338, (_1335 * _61))));
+      _1352 = max(6.103519990574569e-05f, mad(_66, _1341, mad(_65, _1338, (_1335 * _64))));
+      _1353 = max(6.103519990574569e-05f, mad(_69, _1341, mad(_68, _1338, (_1335 * _67))));
+      _2912 = min((_1351 * 4.5f), ((exp2(log2(max(_1351, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+      _2913 = min((_1352 * 4.5f), ((exp2(log2(max(_1352, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+      _2914 = min((_1353 * 4.5f), ((exp2(log2(max(_1353, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+    } else {
+      if ((cb0_040w == 3) || (cb0_040w == 5)) {
+        _9[0] = cb0_010x;
+        _9[1] = cb0_010y;
+        _9[2] = cb0_010z;
+        _9[3] = cb0_010w;
+        _9[4] = cb0_012x;
+        _9[5] = cb0_012x;
+        _10[0] = cb0_011x;
+        _10[1] = cb0_011y;
+        _10[2] = cb0_011z;
+        _10[3] = cb0_011w;
+        _10[4] = cb0_012y;
+        _10[5] = cb0_012y;
+        _1429 = cb0_012z * _1228;
+        _1430 = cb0_012z * _1229;
+        _1431 = cb0_012z * _1230;
+        _1434 = mad((WorkingColorSpace_256[0].z), _1431, mad((WorkingColorSpace_256[0].y), _1430, ((WorkingColorSpace_256[0].x) * _1429)));
+        _1437 = mad((WorkingColorSpace_256[1].z), _1431, mad((WorkingColorSpace_256[1].y), _1430, ((WorkingColorSpace_256[1].x) * _1429)));
+        _1440 = mad((WorkingColorSpace_256[2].z), _1431, mad((WorkingColorSpace_256[2].y), _1430, ((WorkingColorSpace_256[2].x) * _1429)));
+        _1443 = mad(-0.21492856740951538f, _1440, mad(-0.2365107536315918f, _1437, (_1434 * 1.4514392614364624f)));
+        _1446 = mad(-0.09967592358589172f, _1440, mad(1.17622971534729f, _1437, (_1434 * -0.07655377686023712f)));
+        _1449 = mad(0.9977163076400757f, _1440, mad(-0.006032449658960104f, _1437, (_1434 * 0.008316148072481155f)));
+        _1451 = max(_1443, max(_1446, _1449));
+        do {
+          _1519 = _1443;
+          _1520 = _1446;
+          _1521 = _1449;
+          if (!(_1451 < 1.000000013351432e-10f)) {
+            if (!(((_1434 < 0.0f) || (_1437 < 0.0f)) || (_1440 < 0.0f))) {
+              _1461 = abs(_1451);
+              _1462 = (_1451 - _1443) / _1461;
+              _1464 = (_1451 - _1446) / _1461;
+              _1466 = (_1451 - _1449) / _1461;
+              do {
+                _1481 = _1462;
+                if (!(_1462 < 0.8149999976158142f)) {
+                  _1469 = _1462 + -0.8149999976158142f;
+                  _1481 = ((_1469 / exp2(log2(exp2(log2(_1469 * 3.0552830696105957f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8149999976158142f);
+                }
+                do {
+                  _1496 = _1464;
+                  if (!(_1464 < 0.8029999732971191f)) {
+                    _1484 = _1464 + -0.8029999732971191f;
+                    _1496 = ((_1484 / exp2(log2(exp2(log2(_1484 * 3.4972610473632812f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8029999732971191f);
+                  }
+                  do {
+                    _1511 = _1466;
+                    if (!(_1466 < 0.8799999952316284f)) {
+                      _1499 = _1466 + -0.8799999952316284f;
+                      _1511 = ((_1499 / exp2(log2(exp2(log2(_1499 * 6.810994625091553f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8799999952316284f);
+                    }
+                    _1519 = (_1451 - (_1461 * _1481));
+                    _1520 = (_1451 - (_1461 * _1496));
+                    _1521 = (_1451 - (_1461 * _1511));
+                  } while (false);
+                } while (false);
+              } while (false);
+            } else {
+              _1519 = _1443;
+              _1520 = _1446;
+              _1521 = _1449;
+            }
+          }
+          _1537 = ((mad(0.16386906802654266f, _1521, mad(0.14067870378494263f, _1520, (_1519 * 0.6954522132873535f))) - _1434) * cb0_012w) + _1434;
+          _1538 = ((mad(0.0955343171954155f, _1521, mad(0.8596711158752441f, _1520, (_1519 * 0.044794563204050064f))) - _1437) * cb0_012w) + _1437;
+          _1539 = ((mad(1.0015007257461548f, _1521, mad(0.004025210160762072f, _1520, (_1519 * -0.005525882821530104f))) - _1440) * cb0_012w) + _1440;
+          _1543 = max(max(_1537, _1538), _1539);
+          _1548 = (max(_1543, 1.000000013351432e-10f) - max(min(min(_1537, _1538), _1539), 1.000000013351432e-10f)) / max(_1543, 0.009999999776482582f);
+          _1561 = ((_1538 + _1537) + _1539) + (sqrt((((_1539 - _1538) * _1539) + ((_1538 - _1537) * _1538)) + ((_1537 - _1539) * _1537)) * 1.75f);
+          _1562 = _1561 * 0.3333333432674408f;
+          _1563 = _1548 + -0.4000000059604645f;
+          _1564 = _1563 * 5.0f;
+          _1568 = max((1.0f - abs(_1563 * 2.5f)), 0.0f);
+          _1579 = ((float((int)(((int)(uint)((int)(_1564 > 0.0f))) - ((int)(uint)((int)(_1564 < 0.0f))))) * (1.0f - (_1568 * _1568))) + 1.0f) * 0.02500000037252903f;
+          do {
+            _1588 = _1579;
+            if (!(_1562 <= 0.0533333346247673f)) {
+              if (!(_1562 >= 0.1599999964237213f)) {
+                _1588 = (((0.23999999463558197f / _1561) + -0.5f) * _1579);
+              } else {
+                _1588 = 0.0f;
+              }
+            }
+            _1589 = _1588 + 1.0f;
+            _1590 = _1589 * _1537;
+            _1591 = _1589 * _1538;
+            _1592 = _1589 * _1539;
+            do {
+              _1621 = 0.0f;
+              if (!((_1590 == _1591) && (_1591 == _1592))) {
+                _1599 = ((_1590 * 2.0f) - _1591) - _1592;
+                _1602 = ((_1538 - _1539) * 1.7320507764816284f) * _1589;
+                _1604 = atan(_1602 / _1599);
+                _1607 = (_1599 < 0.0f);
+                _1608 = (_1599 == 0.0f);
+                _1609 = (_1602 >= 0.0f);
+                _1610 = (_1602 < 0.0f);
+                _1621 = select((_1609 && _1608), 90.0f, select((_1610 && _1608), -90.0f, (select((_1610 && _1607), (_1604 + -3.1415927410125732f), select((_1609 && _1607), (_1604 + 3.1415927410125732f), _1604)) * 57.2957763671875f)));
+              }
+              _1626 = min(max(select((_1621 < 0.0f), (_1621 + 360.0f), _1621), 0.0f), 360.0f);
+              do {
+                if (_1626 < -180.0f) {
+                  _1635 = (_1626 + 360.0f);
+                } else {
+                  if (_1626 > 180.0f) {
+                    _1635 = (_1626 + -360.0f);
+                  } else {
+                    _1635 = _1626;
+                  }
+                }
+                do {
+                  _1674 = 0.0f;
+                  if ((_1635 > -67.5f) && (_1635 < 67.5f)) {
+                    _1641 = (_1635 + 67.5f) * 0.029629629105329514f;
+                    _1642 = int(_1641);
+                    _1644 = _1641 - float((int)(_1642));
+                    _1645 = _1644 * _1644;
+                    _1646 = _1645 * _1644;
+                    if (_1642 == 3) {
+                      _1674 = (((0.1666666716337204f - (_1644 * 0.5f)) + (_1645 * 0.5f)) - (_1646 * 0.1666666716337204f));
+                    } else {
+                      if (_1642 == 2) {
+                        _1674 = ((0.6666666865348816f - _1645) + (_1646 * 0.5f));
+                      } else {
+                        if (_1642 == 1) {
+                          _1674 = (((_1646 * -0.5f) + 0.1666666716337204f) + ((_1645 + _1644) * 0.5f));
+                        } else {
+                          _1674 = select((_1642 == 0), (_1646 * 0.1666666716337204f), 0.0f);
+                        }
+                      }
+                    }
+                  }
+                  _1683 = min(max(((((_1548 * 0.27000001072883606f) * (0.029999999329447746f - _1590)) * _1674) + _1590), 0.0f), 65535.0f);
+                  _1684 = min(max(_1591, 0.0f), 65535.0f);
+                  _1685 = min(max(_1592, 0.0f), 65535.0f);
+                  _1698 = min(max(mad(-0.21492856740951538f, _1685, mad(-0.2365107536315918f, _1684, (_1683 * 1.4514392614364624f))), 0.0f), 65504.0f);
+                  _1699 = min(max(mad(-0.09967592358589172f, _1685, mad(1.17622971534729f, _1684, (_1683 * -0.07655377686023712f))), 0.0f), 65504.0f);
+                  _1700 = min(max(mad(0.9977163076400757f, _1685, mad(-0.006032449658960104f, _1684, (_1683 * 0.008316148072481155f))), 0.0f), 65504.0f);
+                  _1701 = dot(float3(_1698, _1699, _1700), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+                  _17[0] = cb0_010x;
+                  _17[1] = cb0_010y;
+                  _17[2] = cb0_010z;
+                  _17[3] = cb0_010w;
+                  _17[4] = cb0_012x;
+                  _17[5] = cb0_012x;
+                  _18[0] = cb0_011x;
+                  _18[1] = cb0_011y;
+                  _18[2] = cb0_011z;
+                  _18[3] = cb0_011w;
+                  _18[4] = cb0_012y;
+                  _18[5] = cb0_012y;
+                  _1724 = log2(max((lerp(_1701, _1698, 0.9599999785423279f)), 1.000000013351432e-10f));
+                  _1725 = _1724 * 0.3010300099849701f;
+                  _1726 = log2(cb0_008x);
+                  _1727 = _1726 * 0.3010300099849701f;
+                  do {
+                    if (!(!(_1725 <= _1727))) {
+                      _1796 = (log2(cb0_008y) * 0.3010300099849701f);
+                    } else {
+                      _1734 = log2(cb0_009x);
+                      _1735 = _1734 * 0.3010300099849701f;
+                      if ((_1725 > _1727) && (_1725 < _1735)) {
+                        _1743 = ((_1724 - _1726) * 0.9030900001525879f) / ((_1734 - _1726) * 0.3010300099849701f);
+                        _1744 = int(_1743);
+                        _1746 = _1743 - float((int)(_1744));
+                        _1748 = _17[min((uint)(_1744), 5u)];
+                        _1751 = _17[min((uint)((_1744 + 1)), 5u)];
+                        _1756 = _1748 * 0.5f;
+                        _1796 = dot(float3((_1746 * _1746), _1746, 1.0f), float3(mad((_17[min((uint)((_1744 + 2)), 5u)]), 0.5f, mad(_1751, -1.0f, _1756)), (_1751 - _1748), mad(_1751, 0.5f, _1756)));
+                      } else {
+                        if (!(!(_1725 >= _1735))) {
+                          _1765 = log2(cb0_008z);
+                          if (_1725 < (_1765 * 0.3010300099849701f)) {
+                            _1773 = ((_1724 - _1734) * 0.9030900001525879f) / ((_1765 - _1734) * 0.3010300099849701f);
+                            _1774 = int(_1773);
+                            _1776 = _1773 - float((int)(_1774));
+                            _1778 = _18[min((uint)(_1774), 5u)];
+                            _1781 = _18[min((uint)((_1774 + 1)), 5u)];
+                            _1786 = _1778 * 0.5f;
+                            _1796 = dot(float3((_1776 * _1776), _1776, 1.0f), float3(mad((_18[min((uint)((_1774 + 2)), 5u)]), 0.5f, mad(_1781, -1.0f, _1786)), (_1781 - _1778), mad(_1781, 0.5f, _1786)));
+                          } else {
+                            _1796 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        } else {
+                          _1796 = (log2(cb0_008w) * 0.3010300099849701f);
+                        }
+                      }
+                    }
+                    _19[0] = cb0_010x;
+                    _19[1] = cb0_010y;
+                    _19[2] = cb0_010z;
+                    _19[3] = cb0_010w;
+                    _19[4] = cb0_012x;
+                    _19[5] = cb0_012x;
+                    _20[0] = cb0_011x;
+                    _20[1] = cb0_011y;
+                    _20[2] = cb0_011z;
+                    _20[3] = cb0_011w;
+                    _20[4] = cb0_012y;
+                    _20[5] = cb0_012y;
+                    _1812 = log2(max((lerp(_1701, _1699, 0.9599999785423279f)), 1.000000013351432e-10f));
+                    _1813 = _1812 * 0.3010300099849701f;
+                    do {
+                      if (!(!(_1813 <= _1727))) {
+                        _1882 = (log2(cb0_008y) * 0.3010300099849701f);
+                      } else {
+                        _1820 = log2(cb0_009x);
+                        _1821 = _1820 * 0.3010300099849701f;
+                        if ((_1813 > _1727) && (_1813 < _1821)) {
+                          _1829 = ((_1812 - _1726) * 0.9030900001525879f) / ((_1820 - _1726) * 0.3010300099849701f);
+                          _1830 = int(_1829);
+                          _1832 = _1829 - float((int)(_1830));
+                          _1834 = _19[min((uint)(_1830), 5u)];
+                          _1837 = _19[min((uint)((_1830 + 1)), 5u)];
+                          _1842 = _1834 * 0.5f;
+                          _1882 = dot(float3((_1832 * _1832), _1832, 1.0f), float3(mad((_19[min((uint)((_1830 + 2)), 5u)]), 0.5f, mad(_1837, -1.0f, _1842)), (_1837 - _1834), mad(_1837, 0.5f, _1842)));
+                        } else {
+                          if (!(!(_1813 >= _1821))) {
+                            _1851 = log2(cb0_008z);
+                            if (_1813 < (_1851 * 0.3010300099849701f)) {
+                              _1859 = ((_1812 - _1820) * 0.9030900001525879f) / ((_1851 - _1820) * 0.3010300099849701f);
+                              _1860 = int(_1859);
+                              _1862 = _1859 - float((int)(_1860));
+                              _1864 = _20[min((uint)(_1860), 5u)];
+                              _1867 = _20[min((uint)((_1860 + 1)), 5u)];
+                              _1872 = _1864 * 0.5f;
+                              _1882 = dot(float3((_1862 * _1862), _1862, 1.0f), float3(mad((_20[min((uint)((_1860 + 2)), 5u)]), 0.5f, mad(_1867, -1.0f, _1872)), (_1867 - _1864), mad(_1867, 0.5f, _1872)));
+                            } else {
+                              _1882 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          } else {
+                            _1882 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        }
+                      }
+                      _1886 = log2(max((lerp(_1701, _1700, 0.9599999785423279f)), 1.000000013351432e-10f));
+                      _1887 = _1886 * 0.3010300099849701f;
+                      do {
+                        if (!(!(_1887 <= _1727))) {
+                          _1956 = (log2(cb0_008y) * 0.3010300099849701f);
+                        } else {
+                          _1894 = log2(cb0_009x);
+                          _1895 = _1894 * 0.3010300099849701f;
+                          if ((_1887 > _1727) && (_1887 < _1895)) {
+                            _1903 = ((_1886 - _1726) * 0.9030900001525879f) / ((_1894 - _1726) * 0.3010300099849701f);
+                            _1904 = int(_1903);
+                            _1906 = _1903 - float((int)(_1904));
+                            _1908 = _9[min((uint)(_1904), 5u)];
+                            _1911 = _9[min((uint)((_1904 + 1)), 5u)];
+                            _1916 = _1908 * 0.5f;
+                            _1956 = dot(float3((_1906 * _1906), _1906, 1.0f), float3(mad((_9[min((uint)((_1904 + 2)), 5u)]), 0.5f, mad(_1911, -1.0f, _1916)), (_1911 - _1908), mad(_1911, 0.5f, _1916)));
+                          } else {
+                            if (!(!(_1887 >= _1895))) {
+                              _1925 = log2(cb0_008z);
+                              if (_1887 < (_1925 * 0.3010300099849701f)) {
+                                _1933 = ((_1886 - _1894) * 0.9030900001525879f) / ((_1925 - _1894) * 0.3010300099849701f);
+                                _1934 = int(_1933);
+                                _1936 = _1933 - float((int)(_1934));
+                                _1938 = _10[min((uint)(_1934), 5u)];
+                                _1941 = _10[min((uint)((_1934 + 1)), 5u)];
+                                _1946 = _1938 * 0.5f;
+                                _1956 = dot(float3((_1936 * _1936), _1936, 1.0f), float3(mad((_10[min((uint)((_1934 + 2)), 5u)]), 0.5f, mad(_1941, -1.0f, _1946)), (_1941 - _1938), mad(_1941, 0.5f, _1946)));
+                              } else {
+                                _1956 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            } else {
+                              _1956 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          }
+                        }
+                        _1960 = cb0_008w - cb0_008y;
+                        _1961 = (exp2(_1796 * 3.321928024291992f) - cb0_008y) / _1960;
+                        _1963 = (exp2(_1882 * 3.321928024291992f) - cb0_008y) / _1960;
+                        _1965 = (exp2(_1956 * 3.321928024291992f) - cb0_008y) / _1960;
+                        _1968 = mad(0.15618768334388733f, _1965, mad(0.13400420546531677f, _1963, (_1961 * 0.6624541878700256f)));
+                        _1971 = mad(0.053689517080783844f, _1965, mad(0.6740817427635193f, _1963, (_1961 * 0.2722287178039551f)));
+                        _1974 = mad(1.0103391408920288f, _1965, mad(0.00406073359772563f, _1963, (_1961 * -0.005574649665504694f)));
+                        _1987 = min(max(mad(-0.23642469942569733f, _1974, mad(-0.32480329275131226f, _1971, (_1968 * 1.6410233974456787f))), 0.0f), 1.0f);
+                        _1988 = min(max(mad(0.016756348311901093f, _1974, mad(1.6153316497802734f, _1971, (_1968 * -0.663662850856781f))), 0.0f), 1.0f);
+                        _1989 = min(max(mad(0.9883948564529419f, _1974, mad(-0.008284442126750946f, _1971, (_1968 * 0.011721894145011902f))), 0.0f), 1.0f);
+                        _1992 = mad(0.15618768334388733f, _1989, mad(0.13400420546531677f, _1988, (_1987 * 0.6624541878700256f)));
+                        _1995 = mad(0.053689517080783844f, _1989, mad(0.6740817427635193f, _1988, (_1987 * 0.2722287178039551f)));
+                        _1998 = mad(1.0103391408920288f, _1989, mad(0.00406073359772563f, _1988, (_1987 * -0.005574649665504694f)));
+                        _2020 = min(max((min(max(mad(-0.23642469942569733f, _1998, mad(-0.32480329275131226f, _1995, (_1992 * 1.6410233974456787f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        _2021 = min(max((min(max(mad(0.016756348311901093f, _1998, mad(1.6153316497802734f, _1995, (_1992 * -0.663662850856781f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        _2022 = min(max((min(max(mad(0.9883948564529419f, _1998, mad(-0.008284442126750946f, _1995, (_1992 * 0.011721894145011902f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        do {
+                          _2035 = _2020;
+                          _2036 = _2021;
+                          _2037 = _2022;
+                          if (!(cb0_040w == 5)) {
+                            _2035 = mad(_63, _2022, mad(_62, _2021, (_2020 * _61)));
+                            _2036 = mad(_66, _2022, mad(_65, _2021, (_2020 * _64)));
+                            _2037 = mad(_69, _2022, mad(_68, _2021, (_2020 * _67)));
+                          }
+                          _2047 = exp2(log2(_2035 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _2048 = exp2(log2(_2036 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _2049 = exp2(log2(_2037 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _2912 = exp2(log2((1.0f / ((_2047 * 18.6875f) + 1.0f)) * ((_2047 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          _2913 = exp2(log2((1.0f / ((_2048 * 18.6875f) + 1.0f)) * ((_2048 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          _2914 = exp2(log2((1.0f / ((_2049 * 18.6875f) + 1.0f)) * ((_2049 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                        } while (false);
+                      } while (false);
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } while (false);
+            } while (false);
+          } while (false);
+        } while (false);
+      } else {
+        if ((cb0_040w & -3) == 4) {
+          _2115 = cb0_012z * _1228;
+          _2116 = cb0_012z * _1229;
+          _2117 = cb0_012z * _1230;
+          _2120 = mad((WorkingColorSpace_256[0].z), _2117, mad((WorkingColorSpace_256[0].y), _2116, ((WorkingColorSpace_256[0].x) * _2115)));
+          _2123 = mad((WorkingColorSpace_256[1].z), _2117, mad((WorkingColorSpace_256[1].y), _2116, ((WorkingColorSpace_256[1].x) * _2115)));
+          _2126 = mad((WorkingColorSpace_256[2].z), _2117, mad((WorkingColorSpace_256[2].y), _2116, ((WorkingColorSpace_256[2].x) * _2115)));
+          _2129 = mad(-0.21492856740951538f, _2126, mad(-0.2365107536315918f, _2123, (_2120 * 1.4514392614364624f)));
+          _2132 = mad(-0.09967592358589172f, _2126, mad(1.17622971534729f, _2123, (_2120 * -0.07655377686023712f)));
+          _2135 = mad(0.9977163076400757f, _2126, mad(-0.006032449658960104f, _2123, (_2120 * 0.008316148072481155f)));
+          _2137 = max(_2129, max(_2132, _2135));
+          do {
+            _2205 = _2129;
+            _2206 = _2132;
+            _2207 = _2135;
+            if (!(_2137 < 1.000000013351432e-10f)) {
+              if (!(((_2120 < 0.0f) || (_2123 < 0.0f)) || (_2126 < 0.0f))) {
+                _2147 = abs(_2137);
+                _2148 = (_2137 - _2129) / _2147;
+                _2150 = (_2137 - _2132) / _2147;
+                _2152 = (_2137 - _2135) / _2147;
+                do {
+                  _2167 = _2148;
+                  if (!(_2148 < 0.8149999976158142f)) {
+                    _2155 = _2148 + -0.8149999976158142f;
+                    _2167 = ((_2155 / exp2(log2(exp2(log2(_2155 * 3.0552830696105957f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8149999976158142f);
+                  }
+                  do {
+                    _2182 = _2150;
+                    if (!(_2150 < 0.8029999732971191f)) {
+                      _2170 = _2150 + -0.8029999732971191f;
+                      _2182 = ((_2170 / exp2(log2(exp2(log2(_2170 * 3.4972610473632812f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8029999732971191f);
+                    }
+                    do {
+                      _2197 = _2152;
+                      if (!(_2152 < 0.8799999952316284f)) {
+                        _2185 = _2152 + -0.8799999952316284f;
+                        _2197 = ((_2185 / exp2(log2(exp2(log2(_2185 * 6.810994625091553f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8799999952316284f);
+                      }
+                      _2205 = (_2137 - (_2147 * _2167));
+                      _2206 = (_2137 - (_2147 * _2182));
+                      _2207 = (_2137 - (_2147 * _2197));
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } else {
+                _2205 = _2129;
+                _2206 = _2132;
+                _2207 = _2135;
+              }
+            }
+            _2223 = ((mad(0.16386906802654266f, _2207, mad(0.14067870378494263f, _2206, (_2205 * 0.6954522132873535f))) - _2120) * cb0_012w) + _2120;
+            _2224 = ((mad(0.0955343171954155f, _2207, mad(0.8596711158752441f, _2206, (_2205 * 0.044794563204050064f))) - _2123) * cb0_012w) + _2123;
+            _2225 = ((mad(1.0015007257461548f, _2207, mad(0.004025210160762072f, _2206, (_2205 * -0.005525882821530104f))) - _2126) * cb0_012w) + _2126;
+            _2229 = max(max(_2223, _2224), _2225);
+            _2234 = (max(_2229, 1.000000013351432e-10f) - max(min(min(_2223, _2224), _2225), 1.000000013351432e-10f)) / max(_2229, 0.009999999776482582f);
+            _2247 = ((_2224 + _2223) + _2225) + (sqrt((((_2225 - _2224) * _2225) + ((_2224 - _2223) * _2224)) + ((_2223 - _2225) * _2223)) * 1.75f);
+            _2248 = _2247 * 0.3333333432674408f;
+            _2249 = _2234 + -0.4000000059604645f;
+            _2250 = _2249 * 5.0f;
+            _2254 = max((1.0f - abs(_2249 * 2.5f)), 0.0f);
+            _2265 = ((float((int)(((int)(uint)((int)(_2250 > 0.0f))) - ((int)(uint)((int)(_2250 < 0.0f))))) * (1.0f - (_2254 * _2254))) + 1.0f) * 0.02500000037252903f;
+            do {
+              _2274 = _2265;
+              if (!(_2248 <= 0.0533333346247673f)) {
+                if (!(_2248 >= 0.1599999964237213f)) {
+                  _2274 = (((0.23999999463558197f / _2247) + -0.5f) * _2265);
+                } else {
+                  _2274 = 0.0f;
+                }
+              }
+              _2275 = _2274 + 1.0f;
+              _2276 = _2275 * _2223;
+              _2277 = _2275 * _2224;
+              _2278 = _2275 * _2225;
+              do {
+                _2307 = 0.0f;
+                if (!((_2276 == _2277) && (_2277 == _2278))) {
+                  _2285 = ((_2276 * 2.0f) - _2277) - _2278;
+                  _2288 = ((_2224 - _2225) * 1.7320507764816284f) * _2275;
+                  _2290 = atan(_2288 / _2285);
+                  _2293 = (_2285 < 0.0f);
+                  _2294 = (_2285 == 0.0f);
+                  _2295 = (_2288 >= 0.0f);
+                  _2296 = (_2288 < 0.0f);
+                  _2307 = select((_2295 && _2294), 90.0f, select((_2296 && _2294), -90.0f, (select((_2296 && _2293), (_2290 + -3.1415927410125732f), select((_2295 && _2293), (_2290 + 3.1415927410125732f), _2290)) * 57.2957763671875f)));
+                }
+                _2312 = min(max(select((_2307 < 0.0f), (_2307 + 360.0f), _2307), 0.0f), 360.0f);
+                do {
+                  if (_2312 < -180.0f) {
+                    _2321 = (_2312 + 360.0f);
+                  } else {
+                    if (_2312 > 180.0f) {
+                      _2321 = (_2312 + -360.0f);
+                    } else {
+                      _2321 = _2312;
+                    }
+                  }
+                  do {
+                    _2360 = 0.0f;
+                    if ((_2321 > -67.5f) && (_2321 < 67.5f)) {
+                      _2327 = (_2321 + 67.5f) * 0.029629629105329514f;
+                      _2328 = int(_2327);
+                      _2330 = _2327 - float((int)(_2328));
+                      _2331 = _2330 * _2330;
+                      _2332 = _2331 * _2330;
+                      if (_2328 == 3) {
+                        _2360 = (((0.1666666716337204f - (_2330 * 0.5f)) + (_2331 * 0.5f)) - (_2332 * 0.1666666716337204f));
+                      } else {
+                        if (_2328 == 2) {
+                          _2360 = ((0.6666666865348816f - _2331) + (_2332 * 0.5f));
+                        } else {
+                          if (_2328 == 1) {
+                            _2360 = (((_2332 * -0.5f) + 0.1666666716337204f) + ((_2331 + _2330) * 0.5f));
+                          } else {
+                            _2360 = select((_2328 == 0), (_2332 * 0.1666666716337204f), 0.0f);
+                          }
+                        }
+                      }
+                    }
+                    _2369 = min(max(((((_2234 * 0.27000001072883606f) * (0.029999999329447746f - _2276)) * _2360) + _2276), 0.0f), 65535.0f);
+                    _2370 = min(max(_2277, 0.0f), 65535.0f);
+                    _2371 = min(max(_2278, 0.0f), 65535.0f);
+                    _2384 = min(max(mad(-0.21492856740951538f, _2371, mad(-0.2365107536315918f, _2370, (_2369 * 1.4514392614364624f))), 0.0f), 65504.0f);
+                    _2385 = min(max(mad(-0.09967592358589172f, _2371, mad(1.17622971534729f, _2370, (_2369 * -0.07655377686023712f))), 0.0f), 65504.0f);
+                    _2386 = min(max(mad(0.9977163076400757f, _2371, mad(-0.006032449658960104f, _2370, (_2369 * 0.008316148072481155f))), 0.0f), 65504.0f);
+                    _2387 = dot(float3(_2384, _2385, _2386), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+                    _15[0] = cb0_010x;
+                    _15[1] = cb0_010y;
+                    _15[2] = cb0_010z;
+                    _15[3] = cb0_010w;
+                    _15[4] = cb0_012x;
+                    _15[5] = cb0_012x;
+                    _16[0] = cb0_011x;
+                    _16[1] = cb0_011y;
+                    _16[2] = cb0_011z;
+                    _16[3] = cb0_011w;
+                    _16[4] = cb0_012y;
+                    _16[5] = cb0_012y;
+                    _2410 = log2(max((lerp(_2387, _2384, 0.9599999785423279f)), 1.000000013351432e-10f));
+                    _2411 = _2410 * 0.3010300099849701f;
+                    _2412 = log2(cb0_008x);
+                    _2413 = _2412 * 0.3010300099849701f;
+                    do {
+                      if (!(!(_2411 <= _2413))) {
+                        _2482 = (log2(cb0_008y) * 0.3010300099849701f);
+                      } else {
+                        _2420 = log2(cb0_009x);
+                        _2421 = _2420 * 0.3010300099849701f;
+                        if ((_2411 > _2413) && (_2411 < _2421)) {
+                          _2429 = ((_2410 - _2412) * 0.9030900001525879f) / ((_2420 - _2412) * 0.3010300099849701f);
+                          _2430 = int(_2429);
+                          _2432 = _2429 - float((int)(_2430));
+                          _2434 = _15[min((uint)(_2430), 5u)];
+                          _2437 = _15[min((uint)((_2430 + 1)), 5u)];
+                          _2442 = _2434 * 0.5f;
+                          _2482 = dot(float3((_2432 * _2432), _2432, 1.0f), float3(mad((_15[min((uint)((_2430 + 2)), 5u)]), 0.5f, mad(_2437, -1.0f, _2442)), (_2437 - _2434), mad(_2437, 0.5f, _2442)));
+                        } else {
+                          if (!(!(_2411 >= _2421))) {
+                            _2451 = log2(cb0_008z);
+                            if (_2411 < (_2451 * 0.3010300099849701f)) {
+                              _2459 = ((_2410 - _2420) * 0.9030900001525879f) / ((_2451 - _2420) * 0.3010300099849701f);
+                              _2460 = int(_2459);
+                              _2462 = _2459 - float((int)(_2460));
+                              _2464 = _16[min((uint)(_2460), 5u)];
+                              _2467 = _16[min((uint)((_2460 + 1)), 5u)];
+                              _2472 = _2464 * 0.5f;
+                              _2482 = dot(float3((_2462 * _2462), _2462, 1.0f), float3(mad((_16[min((uint)((_2460 + 2)), 5u)]), 0.5f, mad(_2467, -1.0f, _2472)), (_2467 - _2464), mad(_2467, 0.5f, _2472)));
+                            } else {
+                              _2482 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          } else {
+                            _2482 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        }
+                      }
+                      _11[0] = cb0_010x;
+                      _11[1] = cb0_010y;
+                      _11[2] = cb0_010z;
+                      _11[3] = cb0_010w;
+                      _11[4] = cb0_012x;
+                      _11[5] = cb0_012x;
+                      _12[0] = cb0_011x;
+                      _12[1] = cb0_011y;
+                      _12[2] = cb0_011z;
+                      _12[3] = cb0_011w;
+                      _12[4] = cb0_012y;
+                      _12[5] = cb0_012y;
+                      _2498 = log2(max((lerp(_2387, _2385, 0.9599999785423279f)), 1.000000013351432e-10f));
+                      _2499 = _2498 * 0.3010300099849701f;
+                      do {
+                        if (!(!(_2499 <= _2413))) {
+                          _2568 = (log2(cb0_008y) * 0.3010300099849701f);
+                        } else {
+                          _2506 = log2(cb0_009x);
+                          _2507 = _2506 * 0.3010300099849701f;
+                          if ((_2499 > _2413) && (_2499 < _2507)) {
+                            _2515 = ((_2498 - _2412) * 0.9030900001525879f) / ((_2506 - _2412) * 0.3010300099849701f);
+                            _2516 = int(_2515);
+                            _2518 = _2515 - float((int)(_2516));
+                            _2520 = _11[min((uint)(_2516), 5u)];
+                            _2523 = _11[min((uint)((_2516 + 1)), 5u)];
+                            _2528 = _2520 * 0.5f;
+                            _2568 = dot(float3((_2518 * _2518), _2518, 1.0f), float3(mad((_11[min((uint)((_2516 + 2)), 5u)]), 0.5f, mad(_2523, -1.0f, _2528)), (_2523 - _2520), mad(_2523, 0.5f, _2528)));
+                          } else {
+                            if (!(!(_2499 >= _2507))) {
+                              _2537 = log2(cb0_008z);
+                              if (_2499 < (_2537 * 0.3010300099849701f)) {
+                                _2545 = ((_2498 - _2506) * 0.9030900001525879f) / ((_2537 - _2506) * 0.3010300099849701f);
+                                _2546 = int(_2545);
+                                _2548 = _2545 - float((int)(_2546));
+                                _2550 = _12[min((uint)(_2546), 5u)];
+                                _2553 = _12[min((uint)((_2546 + 1)), 5u)];
+                                _2558 = _2550 * 0.5f;
+                                _2568 = dot(float3((_2548 * _2548), _2548, 1.0f), float3(mad((_12[min((uint)((_2546 + 2)), 5u)]), 0.5f, mad(_2553, -1.0f, _2558)), (_2553 - _2550), mad(_2553, 0.5f, _2558)));
+                              } else {
+                                _2568 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            } else {
+                              _2568 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          }
+                        }
+                        _13[0] = cb0_010x;
+                        _13[1] = cb0_010y;
+                        _13[2] = cb0_010z;
+                        _13[3] = cb0_010w;
+                        _13[4] = cb0_012x;
+                        _13[5] = cb0_012x;
+                        _14[0] = cb0_011x;
+                        _14[1] = cb0_011y;
+                        _14[2] = cb0_011z;
+                        _14[3] = cb0_011w;
+                        _14[4] = cb0_012y;
+                        _14[5] = cb0_012y;
+                        _2584 = log2(max((lerp(_2387, _2386, 0.9599999785423279f)), 1.000000013351432e-10f));
+                        _2585 = _2584 * 0.3010300099849701f;
+                        do {
+                          if (!(!(_2585 <= _2413))) {
+                            _2654 = (log2(cb0_008y) * 0.3010300099849701f);
+                          } else {
+                            _2592 = log2(cb0_009x);
+                            _2593 = _2592 * 0.3010300099849701f;
+                            if ((_2585 > _2413) && (_2585 < _2593)) {
+                              _2601 = ((_2584 - _2412) * 0.9030900001525879f) / ((_2592 - _2412) * 0.3010300099849701f);
+                              _2602 = int(_2601);
+                              _2604 = _2601 - float((int)(_2602));
+                              _2606 = _13[min((uint)(_2602), 5u)];
+                              _2609 = _13[min((uint)((_2602 + 1)), 5u)];
+                              _2614 = _2606 * 0.5f;
+                              _2654 = dot(float3((_2604 * _2604), _2604, 1.0f), float3(mad((_13[min((uint)((_2602 + 2)), 5u)]), 0.5f, mad(_2609, -1.0f, _2614)), (_2609 - _2606), mad(_2609, 0.5f, _2614)));
+                            } else {
+                              if (!(!(_2585 >= _2593))) {
+                                _2623 = log2(cb0_008z);
+                                if (_2585 < (_2623 * 0.3010300099849701f)) {
+                                  _2631 = ((_2584 - _2592) * 0.9030900001525879f) / ((_2623 - _2592) * 0.3010300099849701f);
+                                  _2632 = int(_2631);
+                                  _2634 = _2631 - float((int)(_2632));
+                                  _2636 = _14[min((uint)(_2632), 5u)];
+                                  _2639 = _14[min((uint)((_2632 + 1)), 5u)];
+                                  _2644 = _2636 * 0.5f;
+                                  _2654 = dot(float3((_2634 * _2634), _2634, 1.0f), float3(mad((_14[min((uint)((_2632 + 2)), 5u)]), 0.5f, mad(_2639, -1.0f, _2644)), (_2639 - _2636), mad(_2639, 0.5f, _2644)));
+                                } else {
+                                  _2654 = (log2(cb0_008w) * 0.3010300099849701f);
+                                }
+                              } else {
+                                _2654 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            }
+                          }
+                          _2658 = cb0_008w - cb0_008y;
+                          _2659 = (exp2(_2482 * 3.321928024291992f) - cb0_008y) / _2658;
+                          _2661 = (exp2(_2568 * 3.321928024291992f) - cb0_008y) / _2658;
+                          _2663 = (exp2(_2654 * 3.321928024291992f) - cb0_008y) / _2658;
+                          _2666 = mad(0.15618768334388733f, _2663, mad(0.13400420546531677f, _2661, (_2659 * 0.6624541878700256f)));
+                          _2669 = mad(0.053689517080783844f, _2663, mad(0.6740817427635193f, _2661, (_2659 * 0.2722287178039551f)));
+                          _2672 = mad(1.0103391408920288f, _2663, mad(0.00406073359772563f, _2661, (_2659 * -0.005574649665504694f)));
+                          _2685 = min(max(mad(-0.23642469942569733f, _2672, mad(-0.32480329275131226f, _2669, (_2666 * 1.6410233974456787f))), 0.0f), 1.0f);
+                          _2686 = min(max(mad(0.016756348311901093f, _2672, mad(1.6153316497802734f, _2669, (_2666 * -0.663662850856781f))), 0.0f), 1.0f);
+                          _2687 = min(max(mad(0.9883948564529419f, _2672, mad(-0.008284442126750946f, _2669, (_2666 * 0.011721894145011902f))), 0.0f), 1.0f);
+                          _2690 = mad(0.15618768334388733f, _2687, mad(0.13400420546531677f, _2686, (_2685 * 0.6624541878700256f)));
+                          _2693 = mad(0.053689517080783844f, _2687, mad(0.6740817427635193f, _2686, (_2685 * 0.2722287178039551f)));
+                          _2696 = mad(1.0103391408920288f, _2687, mad(0.00406073359772563f, _2686, (_2685 * -0.005574649665504694f)));
+                          _2718 = min(max((min(max(mad(-0.23642469942569733f, _2696, mad(-0.32480329275131226f, _2693, (_2690 * 1.6410233974456787f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          _2719 = min(max((min(max(mad(0.016756348311901093f, _2696, mad(1.6153316497802734f, _2693, (_2690 * -0.663662850856781f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          _2720 = min(max((min(max(mad(0.9883948564529419f, _2696, mad(-0.008284442126750946f, _2693, (_2690 * 0.011721894145011902f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          do {
+                            _2733 = _2718;
+                            _2734 = _2719;
+                            _2735 = _2720;
+                            if (!(cb0_040w == 6)) {
+                              _2733 = mad(_63, _2720, mad(_62, _2719, (_2718 * _61)));
+                              _2734 = mad(_66, _2720, mad(_65, _2719, (_2718 * _64)));
+                              _2735 = mad(_69, _2720, mad(_68, _2719, (_2718 * _67)));
+                            }
+                            _2745 = exp2(log2(_2733 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2746 = exp2(log2(_2734 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2747 = exp2(log2(_2735 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2912 = exp2(log2((1.0f / ((_2745 * 18.6875f) + 1.0f)) * ((_2745 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                            _2913 = exp2(log2((1.0f / ((_2746 * 18.6875f) + 1.0f)) * ((_2746 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                            _2914 = exp2(log2((1.0f / ((_2747 * 18.6875f) + 1.0f)) * ((_2747 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          } while (false);
+                        } while (false);
+                      } while (false);
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } while (false);
+            } while (false);
+          } while (false);
+        } else {
+          if (cb0_040w == 7) {
+            _2792 = mad((WorkingColorSpace_128[0].z), _1230, mad((WorkingColorSpace_128[0].y), _1229, ((WorkingColorSpace_128[0].x) * _1228)));
+            _2795 = mad((WorkingColorSpace_128[1].z), _1230, mad((WorkingColorSpace_128[1].y), _1229, ((WorkingColorSpace_128[1].x) * _1228)));
+            _2798 = mad((WorkingColorSpace_128[2].z), _1230, mad((WorkingColorSpace_128[2].y), _1229, ((WorkingColorSpace_128[2].x) * _1228)));
+            _2817 = exp2(log2(mad(_63, _2798, mad(_62, _2795, (_2792 * _61))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2818 = exp2(log2(mad(_66, _2798, mad(_65, _2795, (_2792 * _64))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2819 = exp2(log2(mad(_69, _2798, mad(_68, _2795, (_2792 * _67))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2912 = exp2(log2((1.0f / ((_2817 * 18.6875f) + 1.0f)) * ((_2817 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+            _2913 = exp2(log2((1.0f / ((_2818 * 18.6875f) + 1.0f)) * ((_2818 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+            _2914 = exp2(log2((1.0f / ((_2819 * 18.6875f) + 1.0f)) * ((_2819 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+          } else {
+            if (!(cb0_040w == 8)) {
+              if (cb0_040w == 9) {
+                _2866 = mad((WorkingColorSpace_128[0].z), _1218, mad((WorkingColorSpace_128[0].y), _1217, ((WorkingColorSpace_128[0].x) * _1216)));
+                _2869 = mad((WorkingColorSpace_128[1].z), _1218, mad((WorkingColorSpace_128[1].y), _1217, ((WorkingColorSpace_128[1].x) * _1216)));
+                _2872 = mad((WorkingColorSpace_128[2].z), _1218, mad((WorkingColorSpace_128[2].y), _1217, ((WorkingColorSpace_128[2].x) * _1216)));
+                _2912 = mad(_63, _2872, mad(_62, _2869, (_2866 * _61)));
+                _2913 = mad(_66, _2872, mad(_65, _2869, (_2866 * _64)));
+                _2914 = mad(_69, _2872, mad(_68, _2869, (_2866 * _67)));
+              } else {
+                _2885 = mad((WorkingColorSpace_128[0].z), _1244, mad((WorkingColorSpace_128[0].y), _1243, ((WorkingColorSpace_128[0].x) * _1242)));
+                _2888 = mad((WorkingColorSpace_128[1].z), _1244, mad((WorkingColorSpace_128[1].y), _1243, ((WorkingColorSpace_128[1].x) * _1242)));
+                _2891 = mad((WorkingColorSpace_128[2].z), _1244, mad((WorkingColorSpace_128[2].y), _1243, ((WorkingColorSpace_128[2].x) * _1242)));
+                _2912 = exp2(log2(mad(_63, _2891, mad(_62, _2888, (_2885 * _61)))) * cb0_040z);
+                _2913 = exp2(log2(mad(_66, _2891, mad(_65, _2888, (_2885 * _64)))) * cb0_040z);
+                _2914 = exp2(log2(mad(_69, _2891, mad(_68, _2888, (_2885 * _67)))) * cb0_040z);
+              }
+            } else {
+              _2912 = _1228;
+              _2913 = _1229;
+              _2914 = _1230;
+            }
+          }
+        }
+      }
+    }
+  }
+  u0[int3((int)(SV_DispatchThreadID.x), (int)(SV_DispatchThreadID.y), (int)(SV_DispatchThreadID.z))] = float4((_2912 * 0.9523810148239136f), (_2913 * 0.9523810148239136f), (_2914 * 0.9523810148239136f), 0.0f);
+}

--- a/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xB2078D4A.cs_6_6.hlsl
+++ b/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xB2078D4A.cs_6_6.hlsl
@@ -1,0 +1,659 @@
+// From Halo Campaign Evolved
+
+#include "../lutbuilderoutput.hlsli"
+
+RWTexture3D<float4> u0 : register(u0);
+
+cbuffer cb0 : register(b0) {
+  float cb0_013x : packoffset(c013.x);
+  float cb0_013y : packoffset(c013.y);
+  float cb0_013z : packoffset(c013.z);
+  float cb0_013w : packoffset(c013.w);
+  float cb0_014x : packoffset(c014.x);
+  float cb0_014y : packoffset(c014.y);
+  float cb0_014z : packoffset(c014.z);
+  float cb0_015x : packoffset(c015.x);
+  float cb0_015y : packoffset(c015.y);
+  float cb0_015z : packoffset(c015.z);
+  float cb0_015w : packoffset(c015.w);
+  float cb0_016x : packoffset(c016.x);
+  float cb0_016y : packoffset(c016.y);
+  float cb0_016z : packoffset(c016.z);
+  float cb0_016w : packoffset(c016.w);
+  float cb0_017x : packoffset(c017.x);
+  float cb0_017y : packoffset(c017.y);
+  float cb0_017z : packoffset(c017.z);
+  float cb0_017w : packoffset(c017.w);
+  float cb0_018x : packoffset(c018.x);
+  float cb0_018y : packoffset(c018.y);
+  float cb0_018z : packoffset(c018.z);
+  float cb0_018w : packoffset(c018.w);
+  float cb0_019x : packoffset(c019.x);
+  float cb0_019y : packoffset(c019.y);
+  float cb0_019z : packoffset(c019.z);
+  float cb0_019w : packoffset(c019.w);
+  float cb0_020x : packoffset(c020.x);
+  float cb0_020y : packoffset(c020.y);
+  float cb0_020z : packoffset(c020.z);
+  float cb0_020w : packoffset(c020.w);
+  float cb0_021x : packoffset(c021.x);
+  float cb0_021y : packoffset(c021.y);
+  float cb0_021z : packoffset(c021.z);
+  float cb0_021w : packoffset(c021.w);
+  float cb0_022x : packoffset(c022.x);
+  float cb0_022y : packoffset(c022.y);
+  float cb0_022z : packoffset(c022.z);
+  float cb0_022w : packoffset(c022.w);
+  float cb0_023x : packoffset(c023.x);
+  float cb0_023y : packoffset(c023.y);
+  float cb0_023z : packoffset(c023.z);
+  float cb0_023w : packoffset(c023.w);
+  float cb0_024x : packoffset(c024.x);
+  float cb0_024y : packoffset(c024.y);
+  float cb0_024z : packoffset(c024.z);
+  float cb0_024w : packoffset(c024.w);
+  float cb0_025x : packoffset(c025.x);
+  float cb0_025y : packoffset(c025.y);
+  float cb0_025z : packoffset(c025.z);
+  float cb0_025w : packoffset(c025.w);
+  float cb0_026x : packoffset(c026.x);
+  float cb0_026y : packoffset(c026.y);
+  float cb0_026z : packoffset(c026.z);
+  float cb0_026w : packoffset(c026.w);
+  float cb0_027x : packoffset(c027.x);
+  float cb0_027y : packoffset(c027.y);
+  float cb0_027z : packoffset(c027.z);
+  float cb0_027w : packoffset(c027.w);
+  float cb0_028x : packoffset(c028.x);
+  float cb0_028y : packoffset(c028.y);
+  float cb0_028z : packoffset(c028.z);
+  float cb0_028w : packoffset(c028.w);
+  float cb0_029x : packoffset(c029.x);
+  float cb0_029y : packoffset(c029.y);
+  float cb0_029z : packoffset(c029.z);
+  float cb0_029w : packoffset(c029.w);
+  float cb0_030x : packoffset(c030.x);
+  float cb0_030y : packoffset(c030.y);
+  float cb0_030z : packoffset(c030.z);
+  float cb0_030w : packoffset(c030.w);
+  float cb0_031x : packoffset(c031.x);
+  float cb0_031y : packoffset(c031.y);
+  float cb0_031z : packoffset(c031.z);
+  float cb0_031w : packoffset(c031.w);
+  float cb0_032x : packoffset(c032.x);
+  float cb0_032y : packoffset(c032.y);
+  float cb0_032z : packoffset(c032.z);
+  float cb0_032w : packoffset(c032.w);
+  float cb0_033x : packoffset(c033.x);
+  float cb0_033y : packoffset(c033.y);
+  float cb0_033z : packoffset(c033.z);
+  float cb0_033w : packoffset(c033.w);
+  float cb0_034x : packoffset(c034.x);
+  float cb0_034y : packoffset(c034.y);
+  float cb0_034z : packoffset(c034.z);
+  float cb0_034w : packoffset(c034.w);
+  float cb0_035x : packoffset(c035.x);
+  float cb0_035y : packoffset(c035.y);
+  float cb0_035z : packoffset(c035.z);
+  float cb0_035w : packoffset(c035.w);
+  float cb0_036x : packoffset(c036.x);
+  float cb0_036y : packoffset(c036.y);
+  float cb0_036z : packoffset(c036.z);
+  float cb0_036w : packoffset(c036.w);
+  float cb0_037x : packoffset(c037.x);
+  float cb0_037y : packoffset(c037.y);
+  float cb0_037z : packoffset(c037.z);
+  float cb0_037w : packoffset(c037.w);
+  float cb0_038x : packoffset(c038.x);
+  float cb0_038y : packoffset(c038.y);
+  int cb0_038w : packoffset(c038.w);
+  float cb0_039x : packoffset(c039.x);
+  float cb0_039y : packoffset(c039.y);
+  float cb0_039z : packoffset(c039.z);
+  float cb0_040y : packoffset(c040.y);
+  int cb0_041x : packoffset(c041.x);
+  float cb0_042x : packoffset(c042.x);
+  float cb0_042y : packoffset(c042.y);
+};
+
+cbuffer cb1 : register(b1) {
+  float4 WorkingColorSpace_000[4] : packoffset(c000.x);
+  float4 WorkingColorSpace_064[4] : packoffset(c004.x);
+  float4 WorkingColorSpace_128[4] : packoffset(c008.x);
+  float4 WorkingColorSpace_192[4] : packoffset(c012.x);
+  float4 WorkingColorSpace_256[4] : packoffset(c016.x);
+  int WorkingColorSpace_320 : packoffset(c020.x);
+};
+
+// DXIL FirstbitHi: returns bit position counting from MSB (leading zeros count)
+uint firstbithigh_msb(int value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+uint firstbithigh_msb(uint value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+
+[numthreads(8, 8, 8)]
+void main(
+  uint3 SV_DispatchThreadID : SV_DispatchThreadID,
+  uint3 SV_GroupID : SV_GroupID,
+  uint3 SV_GroupThreadID : SV_GroupThreadID,
+  uint SV_GroupIndex : SV_GroupIndex
+) {
+  float _20;
+  float _25;
+  float _49;
+  float _50;
+  float _51;
+  float _52;
+  float _53;
+  float _54;
+  float _55;
+  float _56;
+  float _57;
+  float _120;
+  float _827;
+  float _860;
+  float _874;
+  float _938;
+  float _1190;
+  float _1191;
+  float _1192;
+  float _1203;
+  float _1214;
+  float _1225;
+  bool _38;
+  float _70;
+  float _71;
+  float _72;
+  bool _99;
+  float _103;
+  float _134;
+  float _141;
+  float _144;
+  float _149;
+  float _150;
+  float _152;
+  bool _153;
+  float _162;
+  float _164;
+  float _171;
+  float _173;
+  float _175;
+  float _176;
+  float _179;
+  float _182;
+  float _187;
+  float _193;
+  float _194;
+  float _195;
+  float _196;
+  float _197;
+  float _198;
+  float _199;
+  float _200;
+  float _203;
+  float _204;
+  float _205;
+  float _208;
+  float _227;
+  float _228;
+  float _229;
+  float _230;
+  float _231;
+  float _232;
+  float _233;
+  float _234;
+  float _235;
+  float _238;
+  float _241;
+  float _244;
+  float _247;
+  float _250;
+  float _253;
+  float _256;
+  float _259;
+  float _262;
+  float _265;
+  float _268;
+  float _271;
+  float _274;
+  float _277;
+  float _280;
+  float _283;
+  float _286;
+  float _289;
+  float _319;
+  float _322;
+  float _325;
+  float _340;
+  float _343;
+  float _346;
+  float _347;
+  float _351;
+  float _352;
+  float _353;
+  float _365;
+  float _381;
+  float _382;
+  float _383;
+  float _384;
+  float _398;
+  float _412;
+  float _426;
+  float _440;
+  float _454;
+  float _458;
+  float _459;
+  float _460;
+  float _517;
+  float _521;
+  float _522;
+  float _531;
+  float _540;
+  float _549;
+  float _558;
+  float _567;
+  float _630;
+  float _634;
+  float _643;
+  float _652;
+  float _661;
+  float _670;
+  float _679;
+  float _737;
+  float _748;
+  float _750;
+  float _752;
+  float _767;
+  float _768;
+  float _769;
+  float _772;
+  float _775;
+  float _778;
+  float _782;
+  float _787;
+  float _800;
+  float _801;
+  float _802;
+  float _803;
+  float _807;
+  float _818;
+  float _828;
+  float _829;
+  float _830;
+  float _831;
+  float _838;
+  float _841;
+  float _843;
+  bool _846;
+  bool _847;
+  bool _848;
+  bool _849;
+  float _865;
+  float _878;
+  float _882;
+  float _888;
+  float _898;
+  float _899;
+  float _900;
+  float _901;
+  float _916;
+  float _918;
+  float _920;
+  float _929;
+  float _941;
+  float _943;
+  float _947;
+  float _948;
+  float _949;
+  float _953;
+  float _954;
+  float _955;
+  float _956;
+  float _958;
+  float _959;
+  float _960;
+  float _961;
+  float _980;
+  float _982;
+  float _1007;
+  float _1008;
+  float _1009;
+  float _1016;
+  float _1020;
+  float _1021;
+  float _1022;
+  bool _1023;
+  float _1027;
+  float _1028;
+  float _1029;
+  float _1048;
+  float _1049;
+  float _1050;
+  float _1051;
+  float _1071;
+  float _1072;
+  float _1073;
+  float _1089;
+  float _1090;
+  float _1091;
+  float _1113;
+  float _1114;
+  float _1115;
+  float _1141;
+  float _1142;
+  float _1143;
+  float _1164;
+  float _1165;
+  float _1166;
+  float _1173;
+  float _1176;
+  float _1179;
+  _20 = 0.5f / cb0_035x;
+  _25 = cb0_035x + -1.0f;
+  if (!(cb0_041x == 1)) {
+    if (!(cb0_041x == 2)) {
+      if (!(cb0_041x == 3)) {
+        _38 = (cb0_041x == 4);
+        _49 = select(_38, 1.0f, 1.705051064491272f);
+        _50 = select(_38, 0.0f, -0.6217921376228333f);
+        _51 = select(_38, 0.0f, -0.0832589864730835f);
+        _52 = select(_38, 0.0f, -0.13025647401809692f);
+        _53 = select(_38, 1.0f, 1.140804648399353f);
+        _54 = select(_38, 0.0f, -0.010548308491706848f);
+        _55 = select(_38, 0.0f, -0.024003351107239723f);
+        _56 = select(_38, 0.0f, -0.1289689838886261f);
+        _57 = select(_38, 1.0f, 1.1529725790023804f);
+      } else {
+        _49 = 0.6954522132873535f;
+        _50 = 0.14067870378494263f;
+        _51 = 0.16386906802654266f;
+        _52 = 0.044794563204050064f;
+        _53 = 0.8596711158752441f;
+        _54 = 0.0955343171954155f;
+        _55 = -0.005525882821530104f;
+        _56 = 0.004025210160762072f;
+        _57 = 1.0015007257461548f;
+      }
+    } else {
+      _49 = 1.0258246660232544f;
+      _50 = -0.020053181797266006f;
+      _51 = -0.005771636962890625f;
+      _52 = -0.002234415616840124f;
+      _53 = 1.0045864582061768f;
+      _54 = -0.002352118492126465f;
+      _55 = -0.005013350863009691f;
+      _56 = -0.025290070101618767f;
+      _57 = 1.0303035974502563f;
+    }
+  } else {
+    _49 = 1.3792141675949097f;
+    _50 = -0.30886411666870117f;
+    _51 = -0.0703500509262085f;
+    _52 = -0.06933490186929703f;
+    _53 = 1.08229660987854f;
+    _54 = -0.012961871922016144f;
+    _55 = -0.0021590073592960835f;
+    _56 = -0.0454593189060688f;
+    _57 = 1.0476183891296387f;
+  }
+  _70 = (exp2((((cb0_035x * ((cb0_042x * (((float)((uint)SV_DispatchThreadID.x)) + 0.5f)) - _20)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _71 = (exp2((((cb0_035x * ((cb0_042y * (((float)((uint)SV_DispatchThreadID.y)) + 0.5f)) - _20)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _72 = (exp2(((((float)((uint)SV_DispatchThreadID.z)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _99 = (cb0_038w != 0);
+  _103 = 0.9994439482688904f / cb0_035y;
+  if (!(!((cb0_035y * 1.0005563497543335f) <= 7000.0f))) {
+    _120 = (((((2967800.0f - (_103 * 4607000064.0f)) * _103) + 99.11000061035156f) * _103) + 0.24406300485134125f);
+  } else {
+    _120 = (((((1901800.0f - (_103 * 2006400000.0f)) * _103) + 247.47999572753906f) * _103) + 0.23703999817371368f);
+  }
+  _134 = ((((cb0_035y * 1.2864121856637212e-07f) + 0.00015411825734190643f) * cb0_035y) + 0.8601177334785461f) / ((((cb0_035y * 7.081451371959702e-07f) + 0.0008424202096648514f) * cb0_035y) + 1.0f);
+  _141 = cb0_035y * cb0_035y;
+  _144 = ((((cb0_035y * 4.204816761443908e-08f) + 4.228062607580796e-05f) * cb0_035y) + 0.31739872694015503f) / ((1.0f - (cb0_035y * 2.8974181986995973e-05f)) + (_141 * 1.6145605741257896e-07f));
+  _149 = ((_134 * 2.0f) + 4.0f) - (_144 * 8.0f);
+  _150 = (_134 * 3.0f) / _149;
+  _152 = (_144 * 2.0f) / _149;
+  _153 = (cb0_035y < 4000.0f);
+  _162 = ((cb0_035y + 1189.6199951171875f) * cb0_035y) + 1412139.875f;
+  _164 = ((-1137581184.0f - (cb0_035y * 1916156.25f)) - (_141 * 1.5317699909210205f)) / (_162 * _162);
+  _171 = (6193636.0f - (cb0_035y * 179.45599365234375f)) + _141;
+  _173 = ((1974715392.0f - (cb0_035y * 705674.0f)) - (_141 * 308.60699462890625f)) / (_171 * _171);
+  _175 = rsqrt(dot(float2(_164, _173), float2(_164, _173)));
+  _176 = cb0_035z * 0.05000000074505806f;
+  _179 = ((_176 * _173) * _175) + _134;
+  _182 = _144 - ((_176 * _164) * _175);
+  _187 = (4.0f - (_182 * 8.0f)) + (_179 * 2.0f);
+  _193 = (((_179 * 3.0f) / _187) - _150) + select(_153, _150, _120);
+  _194 = (((_182 * 2.0f) / _187) - _152) + select(_153, _152, (((_120 * 2.869999885559082f) + -0.2750000059604645f) - ((_120 * _120) * 3.0f)));
+  _195 = select(_99, _193, 0.3127000033855438f);
+  _196 = select(_99, _194, 0.32899999618530273f);
+  _197 = select(_99, 0.3127000033855438f, _193);
+  _198 = select(_99, 0.32899999618530273f, _194);
+  _199 = max(_196, 1.000000013351432e-10f);
+  _200 = _195 / _199;
+  _203 = ((1.0f - _195) - _196) / _199;
+  _204 = max(_198, 1.000000013351432e-10f);
+  _205 = _197 / _204;
+  _208 = ((1.0f - _197) - _198) / _204;
+  _227 = mad(-0.16140000522136688f, _208, ((_205 * 0.8950999975204468f) + 0.266400009393692f)) / mad(-0.16140000522136688f, _203, ((_200 * 0.8950999975204468f) + 0.266400009393692f));
+  _228 = mad(0.03669999912381172f, _208, (1.7135000228881836f - (_205 * 0.7501999735832214f))) / mad(0.03669999912381172f, _203, (1.7135000228881836f - (_200 * 0.7501999735832214f)));
+  _229 = mad(1.0296000242233276f, _208, ((_205 * 0.03889999911189079f) + -0.06849999725818634f)) / mad(1.0296000242233276f, _203, ((_200 * 0.03889999911189079f) + -0.06849999725818634f));
+  _230 = mad(_228, -0.7501999735832214f, 0.0f);
+  _231 = mad(_228, 1.7135000228881836f, 0.0f);
+  _232 = mad(_228, 0.03669999912381172f, -0.0f);
+  _233 = mad(_229, 0.03889999911189079f, 0.0f);
+  _234 = mad(_229, -0.06849999725818634f, 0.0f);
+  _235 = mad(_229, 1.0296000242233276f, 0.0f);
+  _238 = mad(0.1599626988172531f, _233, mad(-0.1470542997121811f, _230, (_227 * 0.883457362651825f)));
+  _241 = mad(0.1599626988172531f, _234, mad(-0.1470542997121811f, _231, (_227 * 0.26293492317199707f)));
+  _244 = mad(0.1599626988172531f, _235, mad(-0.1470542997121811f, _232, (_227 * -0.15930065512657166f)));
+  _247 = mad(0.04929120093584061f, _233, mad(0.5183603167533875f, _230, (_227 * 0.38695648312568665f)));
+  _250 = mad(0.04929120093584061f, _234, mad(0.5183603167533875f, _231, (_227 * 0.11516613513231277f)));
+  _253 = mad(0.04929120093584061f, _235, mad(0.5183603167533875f, _232, (_227 * -0.0697740763425827f)));
+  _256 = mad(0.9684867262840271f, _233, mad(0.04004279896616936f, _230, (_227 * -0.007634039502590895f)));
+  _259 = mad(0.9684867262840271f, _234, mad(0.04004279896616936f, _231, (_227 * -0.0022720457054674625f)));
+  _262 = mad(0.9684867262840271f, _235, mad(0.04004279896616936f, _232, (_227 * 0.0013765322510153055f)));
+  _265 = mad(_244, (WorkingColorSpace_000[2].x), mad(_241, (WorkingColorSpace_000[1].x), (_238 * (WorkingColorSpace_000[0].x))));
+  _268 = mad(_244, (WorkingColorSpace_000[2].y), mad(_241, (WorkingColorSpace_000[1].y), (_238 * (WorkingColorSpace_000[0].y))));
+  _271 = mad(_244, (WorkingColorSpace_000[2].z), mad(_241, (WorkingColorSpace_000[1].z), (_238 * (WorkingColorSpace_000[0].z))));
+  _274 = mad(_253, (WorkingColorSpace_000[2].x), mad(_250, (WorkingColorSpace_000[1].x), (_247 * (WorkingColorSpace_000[0].x))));
+  _277 = mad(_253, (WorkingColorSpace_000[2].y), mad(_250, (WorkingColorSpace_000[1].y), (_247 * (WorkingColorSpace_000[0].y))));
+  _280 = mad(_253, (WorkingColorSpace_000[2].z), mad(_250, (WorkingColorSpace_000[1].z), (_247 * (WorkingColorSpace_000[0].z))));
+  _283 = mad(_262, (WorkingColorSpace_000[2].x), mad(_259, (WorkingColorSpace_000[1].x), (_256 * (WorkingColorSpace_000[0].x))));
+  _286 = mad(_262, (WorkingColorSpace_000[2].y), mad(_259, (WorkingColorSpace_000[1].y), (_256 * (WorkingColorSpace_000[0].y))));
+  _289 = mad(_262, (WorkingColorSpace_000[2].z), mad(_259, (WorkingColorSpace_000[1].z), (_256 * (WorkingColorSpace_000[0].z))));
+  _319 = mad(mad((WorkingColorSpace_064[0].z), _289, mad((WorkingColorSpace_064[0].y), _280, (_271 * (WorkingColorSpace_064[0].x)))), _72, mad(mad((WorkingColorSpace_064[0].z), _286, mad((WorkingColorSpace_064[0].y), _277, (_268 * (WorkingColorSpace_064[0].x)))), _71, (mad((WorkingColorSpace_064[0].z), _283, mad((WorkingColorSpace_064[0].y), _274, (_265 * (WorkingColorSpace_064[0].x)))) * _70)));
+  _322 = mad(mad((WorkingColorSpace_064[1].z), _289, mad((WorkingColorSpace_064[1].y), _280, (_271 * (WorkingColorSpace_064[1].x)))), _72, mad(mad((WorkingColorSpace_064[1].z), _286, mad((WorkingColorSpace_064[1].y), _277, (_268 * (WorkingColorSpace_064[1].x)))), _71, (mad((WorkingColorSpace_064[1].z), _283, mad((WorkingColorSpace_064[1].y), _274, (_265 * (WorkingColorSpace_064[1].x)))) * _70)));
+  _325 = mad(mad((WorkingColorSpace_064[2].z), _289, mad((WorkingColorSpace_064[2].y), _280, (_271 * (WorkingColorSpace_064[2].x)))), _72, mad(mad((WorkingColorSpace_064[2].z), _286, mad((WorkingColorSpace_064[2].y), _277, (_268 * (WorkingColorSpace_064[2].x)))), _71, (mad((WorkingColorSpace_064[2].z), _283, mad((WorkingColorSpace_064[2].y), _274, (_265 * (WorkingColorSpace_064[2].x)))) * _70)));
+  _340 = mad((WorkingColorSpace_128[0].z), _325, mad((WorkingColorSpace_128[0].y), _322, ((WorkingColorSpace_128[0].x) * _319)));
+  _343 = mad((WorkingColorSpace_128[1].z), _325, mad((WorkingColorSpace_128[1].y), _322, ((WorkingColorSpace_128[1].x) * _319)));
+  _346 = mad((WorkingColorSpace_128[2].z), _325, mad((WorkingColorSpace_128[2].y), _322, ((WorkingColorSpace_128[2].x) * _319)));
+  _347 = dot(float3(_340, _343, _346), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _351 = (_340 / _347) + -1.0f;
+  _352 = (_343 / _347) + -1.0f;
+  _353 = (_346 / _347) + -1.0f;
+  // ExpandGamut set to 0
+  _365 = (1.0f - exp2(((_347 * _347) * -4.0f) * 0.f)) * (1.0f - exp2(dot(float3(_351, _352, _353), float3(_351, _352, _353)) * -4.0f));
+  _381 = ((mad(-0.06368321925401688f, _346, mad(-0.3292922377586365f, _343, (_340 * 1.3704125881195068f))) - _340) * _365) + _340;
+  _382 = ((mad(-0.010861365124583244f, _346, mad(1.0970927476882935f, _343, (_340 * -0.08343357592821121f))) - _343) * _365) + _343;
+  _383 = ((mad(1.2036951780319214f, _346, mad(-0.09862580895423889f, _343, (_340 * -0.02579331398010254f))) - _346) * _365) + _346;
+  _384 = dot(float3(_381, _382, _383), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _398 = cb0_019w + cb0_024w;
+  _412 = cb0_018w * cb0_023w;
+  _426 = cb0_017w * cb0_022w;
+  _440 = cb0_016w * cb0_021w;
+  _454 = cb0_015w * cb0_020w;
+  _458 = _381 - _384;
+  _459 = _382 - _384;
+  _460 = _383 - _384;
+  _517 = saturate(_384 / cb0_035w);
+  _521 = (_517 * _517) * (3.0f - (_517 * 2.0f));
+  _522 = 1.0f - _521;
+  _531 = cb0_019w + cb0_034w;
+  _540 = cb0_018w * cb0_033w;
+  _549 = cb0_017w * cb0_032w;
+  _558 = cb0_016w * cb0_031w;
+  _567 = cb0_015w * cb0_030w;
+  _630 = saturate((_384 - cb0_036x) / (cb0_036y - cb0_036x));
+  _634 = (_630 * _630) * (3.0f - (_630 * 2.0f));
+  _643 = cb0_019w + cb0_029w;
+  _652 = cb0_018w * cb0_028w;
+  _661 = cb0_017w * cb0_027w;
+  _670 = cb0_016w * cb0_026w;
+  _679 = cb0_015w * cb0_025w;
+  _737 = _521 - _634;
+  _748 = ((_634 * (((cb0_019x + cb0_034x) + _531) + (((cb0_018x * cb0_033x) * _540) * exp2(log2(exp2(((cb0_016x * cb0_031x) * _558) * log2(max(0.0f, ((((cb0_015x * cb0_030x) * _567) * _458) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_032x) * _549)))))) + (_522 * (((cb0_019x + cb0_024x) + _398) + (((cb0_018x * cb0_023x) * _412) * exp2(log2(exp2(((cb0_016x * cb0_021x) * _440) * log2(max(0.0f, ((((cb0_015x * cb0_020x) * _454) * _458) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_022x) * _426))))))) + ((((cb0_019x + cb0_029x) + _643) + (((cb0_018x * cb0_028x) * _652) * exp2(log2(exp2(((cb0_016x * cb0_026x) * _670) * log2(max(0.0f, ((((cb0_015x * cb0_025x) * _679) * _458) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_027x) * _661))))) * _737);
+  _750 = ((_634 * (((cb0_019y + cb0_034y) + _531) + (((cb0_018y * cb0_033y) * _540) * exp2(log2(exp2(((cb0_016y * cb0_031y) * _558) * log2(max(0.0f, ((((cb0_015y * cb0_030y) * _567) * _459) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_032y) * _549)))))) + (_522 * (((cb0_019y + cb0_024y) + _398) + (((cb0_018y * cb0_023y) * _412) * exp2(log2(exp2(((cb0_016y * cb0_021y) * _440) * log2(max(0.0f, ((((cb0_015y * cb0_020y) * _454) * _459) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_022y) * _426))))))) + ((((cb0_019y + cb0_029y) + _643) + (((cb0_018y * cb0_028y) * _652) * exp2(log2(exp2(((cb0_016y * cb0_026y) * _670) * log2(max(0.0f, ((((cb0_015y * cb0_025y) * _679) * _459) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_027y) * _661))))) * _737);
+  _752 = ((_634 * (((cb0_019z + cb0_034z) + _531) + (((cb0_018z * cb0_033z) * _540) * exp2(log2(exp2(((cb0_016z * cb0_031z) * _558) * log2(max(0.0f, ((((cb0_015z * cb0_030z) * _567) * _460) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_032z) * _549)))))) + (_522 * (((cb0_019z + cb0_024z) + _398) + (((cb0_018z * cb0_023z) * _412) * exp2(log2(exp2(((cb0_016z * cb0_021z) * _440) * log2(max(0.0f, ((((cb0_015z * cb0_020z) * _454) * _460) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_022z) * _426))))))) + ((((cb0_019z + cb0_029z) + _643) + (((cb0_018z * cb0_028z) * _652) * exp2(log2(exp2(((cb0_016z * cb0_026z) * _670) * log2(max(0.0f, ((((cb0_015z * cb0_025z) * _679) * _460) + _384)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_027z) * _661))))) * _737);
+  UECbufferConfig cb_config = CreateCbufferConfig();
+  cb_config.ue_filmblackclip = cb0_038x;
+  cb_config.ue_filmtoe = cb0_037z;
+  cb_config.ue_filmshoulder = cb0_037w;
+  cb_config.ue_filmslope = cb0_037y;
+  cb_config.ue_filmwhiteclip = cb0_038y;
+  cb_config.ue_tonecurveammount = cb0_037x;
+  cb_config.ue_mappingpolynomial = float3(cb0_039x, cb0_039y, cb0_039z);
+  cb_config.ue_overlaycolor = float4(cb0_013x, cb0_013y, cb0_013z, cb0_013w);
+  cb_config.ue_bluecorrection = cb0_036z;
+  cb_config.ue_colorscale = float3(cb0_014x, cb0_014y, cb0_014z);
+
+  float4 output = ProcessLutbuilder(float3(_748, _750, _752), cb_config, u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))], 3u);
+  u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))] = output;
+  return;
+
+  _767 = ((mad(0.061360642313957214f, _752, mad(-4.540197551250458e-09f, _750, (_748 * 0.9386394023895264f))) - _748) * cb0_036z) + _748;
+  _768 = ((mad(0.169205904006958f, _752, mad(0.8307942152023315f, _750, (_748 * 6.775371730327606e-08f))) - _750) * cb0_036z) + _750;
+  _769 = (mad(-2.3283064365386963e-10f, _750, (_748 * -9.313225746154785e-10f)) * cb0_036z) + _752;
+  _772 = mad(0.16386905312538147f, _769, mad(0.14067868888378143f, _768, (_767 * 0.6954522132873535f)));
+  _775 = mad(0.0955343246459961f, _769, mad(0.8596711158752441f, _768, (_767 * 0.044794581830501556f)));
+  _778 = mad(1.0015007257461548f, _769, mad(0.004025210160762072f, _768, (_767 * -0.005525882821530104f)));
+  _782 = max(max(_772, _775), _778);
+  _787 = (max(_782, 1.000000013351432e-10f) - max(min(min(_772, _775), _778), 1.000000013351432e-10f)) / max(_782, 0.009999999776482582f);
+  _800 = ((_775 + _772) + _778) + (sqrt((((_778 - _775) * _778) + ((_775 - _772) * _775)) + ((_772 - _778) * _772)) * 1.75f);
+  _801 = _800 * 0.3333333432674408f;
+  _802 = _787 + -0.4000000059604645f;
+  _803 = _802 * 5.0f;
+  _807 = max((1.0f - abs(_802 * 2.5f)), 0.0f);
+  _818 = ((float((int)(((int)(uint)((int)(_803 > 0.0f))) - ((int)(uint)((int)(_803 < 0.0f))))) * (1.0f - (_807 * _807))) + 1.0f) * 0.02500000037252903f;
+  if (!(_801 <= 0.0533333346247673f)) {
+    if (!(_801 >= 0.1599999964237213f)) {
+      _827 = (((0.23999999463558197f / _800) + -0.5f) * _818);
+    } else {
+      _827 = 0.0f;
+    }
+  } else {
+    _827 = _818;
+  }
+  _828 = _827 + 1.0f;
+  _829 = _828 * _772;
+  _830 = _828 * _775;
+  _831 = _828 * _778;
+  if (!((_829 == _830) && (_830 == _831))) {
+    _838 = ((_829 * 2.0f) - _830) - _831;
+    _841 = ((_775 - _778) * 1.7320507764816284f) * _828;
+    _843 = atan(_841 / _838);
+    _846 = (_838 < 0.0f);
+    _847 = (_838 == 0.0f);
+    _848 = (_841 >= 0.0f);
+    _849 = (_841 < 0.0f);
+    _860 = select((_848 && _847), 90.0f, select((_849 && _847), -90.0f, (select((_849 && _846), (_843 + -3.1415927410125732f), select((_848 && _846), (_843 + 3.1415927410125732f), _843)) * 57.2957763671875f)));
+  } else {
+    _860 = 0.0f;
+  }
+  _865 = min(max(select((_860 < 0.0f), (_860 + 360.0f), _860), 0.0f), 360.0f);
+  if (_865 < -180.0f) {
+    _874 = (_865 + 360.0f);
+  } else {
+    if (_865 > 180.0f) {
+      _874 = (_865 + -360.0f);
+    } else {
+      _874 = _865;
+    }
+  }
+  _878 = saturate(1.0f - abs(_874 * 0.014814814552664757f));
+  _882 = (_878 * _878) * (3.0f - (_878 * 2.0f));
+  _888 = ((_882 * _882) * ((_787 * 0.18000000715255737f) * (0.029999999329447746f - _829))) + _829;
+  _898 = max(0.0f, mad(-0.21492856740951538f, _831, mad(-0.2365107536315918f, _830, (_888 * 1.4514392614364624f))));
+  _899 = max(0.0f, mad(-0.09967592358589172f, _831, mad(1.17622971534729f, _830, (_888 * -0.07655377686023712f))));
+  _900 = max(0.0f, mad(0.9977163076400757f, _831, mad(-0.006032449658960104f, _830, (_888 * 0.008316148072481155f))));
+  _901 = dot(float3(_898, _899, _900), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _916 = (cb0_038x + 1.0f) - cb0_037z;
+  _918 = cb0_038y + 1.0f;
+  _920 = _918 - cb0_037w;
+  if (cb0_037z > 0.800000011920929f) {
+    _938 = (((0.8199999928474426f - cb0_037z) / cb0_037y) + -0.7447274923324585f);
+  } else {
+    _929 = (cb0_038x + 0.18000000715255737f) / _916;
+    _938 = (-0.7447274923324585f - ((log2(_929 / (2.0f - _929)) * 0.3465735912322998f) * (_916 / cb0_037y)));
+  }
+  _941 = ((1.0f - cb0_037z) / cb0_037y) - _938;
+  _943 = (cb0_037w / cb0_037y) - _941;
+  _947 = log2(lerp(_901, _898, 0.9599999785423279f)) * 0.3010300099849701f;
+  _948 = log2(lerp(_901, _899, 0.9599999785423279f)) * 0.3010300099849701f;
+  _949 = log2(lerp(_901, _900, 0.9599999785423279f)) * 0.3010300099849701f;
+  _953 = cb0_037y * (_947 + _941);
+  _954 = cb0_037y * (_948 + _941);
+  _955 = cb0_037y * (_949 + _941);
+  _956 = _916 * 2.0f;
+  _958 = (cb0_037y * -2.0f) / _916;
+  _959 = _947 - _938;
+  _960 = _948 - _938;
+  _961 = _949 - _938;
+  _980 = _920 * 2.0f;
+  _982 = (cb0_037y * 2.0f) / _920;
+  _1007 = select((_947 < _938), ((_956 / (exp2((_959 * 1.4426950216293335f) * _958) + 1.0f)) - cb0_038x), _953);
+  _1008 = select((_948 < _938), ((_956 / (exp2((_960 * 1.4426950216293335f) * _958) + 1.0f)) - cb0_038x), _954);
+  _1009 = select((_949 < _938), ((_956 / (exp2((_961 * 1.4426950216293335f) * _958) + 1.0f)) - cb0_038x), _955);
+  _1016 = _943 - _938;
+  _1020 = saturate(_959 / _1016);
+  _1021 = saturate(_960 / _1016);
+  _1022 = saturate(_961 / _1016);
+  _1023 = (_943 < _938);
+  _1027 = select(_1023, (1.0f - _1020), _1020);
+  _1028 = select(_1023, (1.0f - _1021), _1021);
+  _1029 = select(_1023, (1.0f - _1022), _1022);
+  _1048 = (((_1027 * _1027) * (select((_947 > _943), (_918 - (_980 / (exp2(((_947 - _943) * 1.4426950216293335f) * _982) + 1.0f))), _953) - _1007)) * (3.0f - (_1027 * 2.0f))) + _1007;
+  _1049 = (((_1028 * _1028) * (select((_948 > _943), (_918 - (_980 / (exp2(((_948 - _943) * 1.4426950216293335f) * _982) + 1.0f))), _954) - _1008)) * (3.0f - (_1028 * 2.0f))) + _1008;
+  _1050 = (((_1029 * _1029) * (select((_949 > _943), (_918 - (_980 / (exp2(((_949 - _943) * 1.4426950216293335f) * _982) + 1.0f))), _955) - _1009)) * (3.0f - (_1029 * 2.0f))) + _1009;
+  _1051 = dot(float3(_1048, _1049, _1050), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _1071 = (cb0_037x * (max(0.0f, (lerp(_1051, _1048, 0.9300000071525574f))) - _767)) + _767;
+  _1072 = (cb0_037x * (max(0.0f, (lerp(_1051, _1049, 0.9300000071525574f))) - _768)) + _768;
+  _1073 = (cb0_037x * (max(0.0f, (lerp(_1051, _1050, 0.9300000071525574f))) - _769)) + _769;
+  _1089 = ((mad(-0.06537103652954102f, _1073, mad(1.451815478503704e-06f, _1072, (_1071 * 1.065374732017517f))) - _1071) * cb0_036z) + _1071;
+  _1090 = ((mad(-0.20366770029067993f, _1073, mad(1.2036634683609009f, _1072, (_1071 * -2.57161445915699e-07f))) - _1072) * cb0_036z) + _1072;
+  _1091 = ((mad(0.9999996423721313f, _1073, mad(2.0954757928848267e-08f, _1072, (_1071 * 1.862645149230957e-08f))) - _1073) * cb0_036z) + _1073;
+  _1113 = max(0.0f, mad((WorkingColorSpace_192[0].z), _1091, mad((WorkingColorSpace_192[0].y), _1090, ((WorkingColorSpace_192[0].x) * _1089))));
+  _1114 = max(0.0f, mad((WorkingColorSpace_192[1].z), _1091, mad((WorkingColorSpace_192[1].y), _1090, ((WorkingColorSpace_192[1].x) * _1089))));
+  _1115 = max(0.0f, mad((WorkingColorSpace_192[2].z), _1091, mad((WorkingColorSpace_192[2].y), _1090, ((WorkingColorSpace_192[2].x) * _1089))));
+  _1141 = cb0_014x * (((cb0_039y + (cb0_039x * _1113)) * _1113) + cb0_039z);
+  _1142 = cb0_014y * (((cb0_039y + (cb0_039x * _1114)) * _1114) + cb0_039z);
+  _1143 = cb0_014z * (((cb0_039y + (cb0_039x * _1115)) * _1115) + cb0_039z);
+  _1164 = exp2(log2(max(0.0f, (lerp(_1141, cb0_013x, cb0_013w)))) * cb0_040y);
+  _1165 = exp2(log2(max(0.0f, (lerp(_1142, cb0_013y, cb0_013w)))) * cb0_040y);
+  _1166 = exp2(log2(max(0.0f, (lerp(_1143, cb0_013z, cb0_013w)))) * cb0_040y);
+  if (WorkingColorSpace_320 == 0) {
+    _1173 = mad((WorkingColorSpace_128[0].z), _1166, mad((WorkingColorSpace_128[0].y), _1165, ((WorkingColorSpace_128[0].x) * _1164)));
+    _1176 = mad((WorkingColorSpace_128[1].z), _1166, mad((WorkingColorSpace_128[1].y), _1165, ((WorkingColorSpace_128[1].x) * _1164)));
+    _1179 = mad((WorkingColorSpace_128[2].z), _1166, mad((WorkingColorSpace_128[2].y), _1165, ((WorkingColorSpace_128[2].x) * _1164)));
+    _1190 = mad(_51, _1179, mad(_50, _1176, (_1173 * _49)));
+    _1191 = mad(_54, _1179, mad(_53, _1176, (_1173 * _52)));
+    _1192 = mad(_57, _1179, mad(_56, _1176, (_1173 * _55)));
+  } else {
+    _1190 = _1164;
+    _1191 = _1165;
+    _1192 = _1166;
+  }
+  if (_1190 < 0.0031306699384003878f) {
+    _1203 = (_1190 * 12.920000076293945f);
+  } else {
+    _1203 = (((pow(_1190, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  if (_1191 < 0.0031306699384003878f) {
+    _1214 = (_1191 * 12.920000076293945f);
+  } else {
+    _1214 = (((pow(_1191, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  if (_1192 < 0.0031306699384003878f) {
+    _1225 = (_1192 * 12.920000076293945f);
+  } else {
+    _1225 = (((pow(_1192, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  u0[int3((int)(SV_DispatchThreadID.x), (int)(SV_DispatchThreadID.y), (int)(SV_DispatchThreadID.z))] = float4((_1203 * 0.9523810148239136f), (_1214 * 0.9523810148239136f), (_1225 * 0.9523810148239136f), 0.0f);
+}

--- a/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xD252BB70.cs_6_6.hlsl
+++ b/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xD252BB70.cs_6_6.hlsl
@@ -1,0 +1,1580 @@
+// From Halo Campaign Evolved
+
+#include "../lutbuilderoutput.hlsli"
+
+RWTexture3D<float4> u0 : register(u0);
+
+cbuffer cb0 : register(b0) {
+  float cb0_008x : packoffset(c008.x);
+  float cb0_008y : packoffset(c008.y);
+  float cb0_008z : packoffset(c008.z);
+  float cb0_008w : packoffset(c008.w);
+  float cb0_009x : packoffset(c009.x);
+  float cb0_010x : packoffset(c010.x);
+  float cb0_010y : packoffset(c010.y);
+  float cb0_010z : packoffset(c010.z);
+  float cb0_010w : packoffset(c010.w);
+  float cb0_011x : packoffset(c011.x);
+  float cb0_011y : packoffset(c011.y);
+  float cb0_011z : packoffset(c011.z);
+  float cb0_011w : packoffset(c011.w);
+  float cb0_012x : packoffset(c012.x);
+  float cb0_012y : packoffset(c012.y);
+  float cb0_012z : packoffset(c012.z);
+  float cb0_012w : packoffset(c012.w);
+  float cb0_013x : packoffset(c013.x);
+  float cb0_013y : packoffset(c013.y);
+  float cb0_013z : packoffset(c013.z);
+  float cb0_013w : packoffset(c013.w);
+  float cb0_014x : packoffset(c014.x);
+  float cb0_014y : packoffset(c014.y);
+  float cb0_014z : packoffset(c014.z);
+  float cb0_015x : packoffset(c015.x);
+  float cb0_015y : packoffset(c015.y);
+  float cb0_015z : packoffset(c015.z);
+  float cb0_015w : packoffset(c015.w);
+  float cb0_016x : packoffset(c016.x);
+  float cb0_016y : packoffset(c016.y);
+  float cb0_016z : packoffset(c016.z);
+  float cb0_016w : packoffset(c016.w);
+  float cb0_017x : packoffset(c017.x);
+  float cb0_017y : packoffset(c017.y);
+  float cb0_017z : packoffset(c017.z);
+  float cb0_017w : packoffset(c017.w);
+  float cb0_018x : packoffset(c018.x);
+  float cb0_018y : packoffset(c018.y);
+  float cb0_018z : packoffset(c018.z);
+  float cb0_018w : packoffset(c018.w);
+  float cb0_019x : packoffset(c019.x);
+  float cb0_019y : packoffset(c019.y);
+  float cb0_019z : packoffset(c019.z);
+  float cb0_019w : packoffset(c019.w);
+  float cb0_020x : packoffset(c020.x);
+  float cb0_020y : packoffset(c020.y);
+  float cb0_020z : packoffset(c020.z);
+  float cb0_020w : packoffset(c020.w);
+  float cb0_021x : packoffset(c021.x);
+  float cb0_021y : packoffset(c021.y);
+  float cb0_021z : packoffset(c021.z);
+  float cb0_021w : packoffset(c021.w);
+  float cb0_022x : packoffset(c022.x);
+  float cb0_022y : packoffset(c022.y);
+  float cb0_022z : packoffset(c022.z);
+  float cb0_022w : packoffset(c022.w);
+  float cb0_023x : packoffset(c023.x);
+  float cb0_023y : packoffset(c023.y);
+  float cb0_023z : packoffset(c023.z);
+  float cb0_023w : packoffset(c023.w);
+  float cb0_024x : packoffset(c024.x);
+  float cb0_024y : packoffset(c024.y);
+  float cb0_024z : packoffset(c024.z);
+  float cb0_024w : packoffset(c024.w);
+  float cb0_025x : packoffset(c025.x);
+  float cb0_025y : packoffset(c025.y);
+  float cb0_025z : packoffset(c025.z);
+  float cb0_025w : packoffset(c025.w);
+  float cb0_026x : packoffset(c026.x);
+  float cb0_026y : packoffset(c026.y);
+  float cb0_026z : packoffset(c026.z);
+  float cb0_026w : packoffset(c026.w);
+  float cb0_027x : packoffset(c027.x);
+  float cb0_027y : packoffset(c027.y);
+  float cb0_027z : packoffset(c027.z);
+  float cb0_027w : packoffset(c027.w);
+  float cb0_028x : packoffset(c028.x);
+  float cb0_028y : packoffset(c028.y);
+  float cb0_028z : packoffset(c028.z);
+  float cb0_028w : packoffset(c028.w);
+  float cb0_029x : packoffset(c029.x);
+  float cb0_029y : packoffset(c029.y);
+  float cb0_029z : packoffset(c029.z);
+  float cb0_029w : packoffset(c029.w);
+  float cb0_030x : packoffset(c030.x);
+  float cb0_030y : packoffset(c030.y);
+  float cb0_030z : packoffset(c030.z);
+  float cb0_030w : packoffset(c030.w);
+  float cb0_031x : packoffset(c031.x);
+  float cb0_031y : packoffset(c031.y);
+  float cb0_031z : packoffset(c031.z);
+  float cb0_031w : packoffset(c031.w);
+  float cb0_032x : packoffset(c032.x);
+  float cb0_032y : packoffset(c032.y);
+  float cb0_032z : packoffset(c032.z);
+  float cb0_032w : packoffset(c032.w);
+  float cb0_033x : packoffset(c033.x);
+  float cb0_033y : packoffset(c033.y);
+  float cb0_033z : packoffset(c033.z);
+  float cb0_033w : packoffset(c033.w);
+  float cb0_034x : packoffset(c034.x);
+  float cb0_034y : packoffset(c034.y);
+  float cb0_034z : packoffset(c034.z);
+  float cb0_034w : packoffset(c034.w);
+  float cb0_035x : packoffset(c035.x);
+  float cb0_035w : packoffset(c035.w);
+  float cb0_036x : packoffset(c036.x);
+  float cb0_036y : packoffset(c036.y);
+  float cb0_036z : packoffset(c036.z);
+  float cb0_036w : packoffset(c036.w);
+  float cb0_037x : packoffset(c037.x);
+  float cb0_037y : packoffset(c037.y);
+  float cb0_037z : packoffset(c037.z);
+  float cb0_037w : packoffset(c037.w);
+  float cb0_038x : packoffset(c038.x);
+  float cb0_038y : packoffset(c038.y);
+  float cb0_039x : packoffset(c039.x);
+  float cb0_039y : packoffset(c039.y);
+  float cb0_039z : packoffset(c039.z);
+  float cb0_040y : packoffset(c040.y);
+  float cb0_040z : packoffset(c040.z);
+  int cb0_040w : packoffset(c040.w);
+  int cb0_041x : packoffset(c041.x);
+  float cb0_042x : packoffset(c042.x);
+  float cb0_042y : packoffset(c042.y);
+};
+
+cbuffer cb1 : register(b1) {
+  float4 WorkingColorSpace_000[4] : packoffset(c000.x);
+  float4 WorkingColorSpace_064[4] : packoffset(c004.x);
+  float4 WorkingColorSpace_128[4] : packoffset(c008.x);
+  float4 WorkingColorSpace_192[4] : packoffset(c012.x);
+  float4 WorkingColorSpace_256[4] : packoffset(c016.x);
+  int WorkingColorSpace_320 : packoffset(c020.x);
+};
+
+// DXIL FirstbitHi: returns bit position counting from MSB (leading zeros count)
+uint firstbithigh_msb(int value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+uint firstbithigh_msb(uint value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+
+[numthreads(8, 8, 8)]
+void main(
+  uint3 SV_DispatchThreadID : SV_DispatchThreadID,
+  uint3 SV_GroupID : SV_GroupID,
+  uint3 SV_GroupThreadID : SV_GroupThreadID,
+  uint SV_GroupIndex : SV_GroupIndex
+) {
+  float _32;
+  float _37;
+  float _38;
+  float _39;
+  float _41;
+  float _61;
+  float _62;
+  float _63;
+  float _64;
+  float _65;
+  float _66;
+  float _67;
+  float _68;
+  float _69;
+  float _127;
+  float _128;
+  float _129;
+  float _652;
+  float _685;
+  float _699;
+  float _763;
+  float _1031;
+  float _1032;
+  float _1033;
+  float _1044;
+  float _1055;
+  float _1228;
+  float _1243;
+  float _1258;
+  float _1266;
+  float _1267;
+  float _1268;
+  float _1335;
+  float _1368;
+  float _1382;
+  float _1421;
+  float _1543;
+  float _1629;
+  float _1703;
+  float _1782;
+  float _1783;
+  float _1784;
+  float _1914;
+  float _1929;
+  float _1944;
+  float _1952;
+  float _1953;
+  float _1954;
+  float _2021;
+  float _2054;
+  float _2068;
+  float _2107;
+  float _2229;
+  float _2315;
+  float _2401;
+  float _2480;
+  float _2481;
+  float _2482;
+  float _2659;
+  float _2660;
+  float _2661;
+  bool _50;
+  float _80;
+  float _81;
+  float _82;
+  float _144;
+  float _147;
+  float _150;
+  float _151;
+  float _155;
+  float _156;
+  float _157;
+  float _169;
+  float _185;
+  float _186;
+  float _187;
+  float _188;
+  float _202;
+  float _216;
+  float _230;
+  float _244;
+  float _258;
+  float _262;
+  float _263;
+  float _264;
+  float _321;
+  float _325;
+  float _326;
+  float _335;
+  float _344;
+  float _353;
+  float _362;
+  float _371;
+  float _434;
+  float _438;
+  float _447;
+  float _456;
+  float _465;
+  float _474;
+  float _483;
+  float _541;
+  float _552;
+  float _554;
+  float _556;
+  float _592;
+  float _593;
+  float _594;
+  float _597;
+  float _600;
+  float _603;
+  float _607;
+  float _612;
+  float _625;
+  float _626;
+  float _627;
+  float _628;
+  float _632;
+  float _643;
+  float _653;
+  float _654;
+  float _655;
+  float _656;
+  float _663;
+  float _666;
+  float _668;
+  bool _671;
+  bool _672;
+  bool _673;
+  bool _674;
+  float _690;
+  float _703;
+  float _707;
+  float _713;
+  float _723;
+  float _724;
+  float _725;
+  float _726;
+  float _741;
+  float _743;
+  float _745;
+  float _754;
+  float _766;
+  float _768;
+  float _772;
+  float _773;
+  float _774;
+  float _778;
+  float _779;
+  float _780;
+  float _781;
+  float _783;
+  float _784;
+  float _785;
+  float _786;
+  float _805;
+  float _807;
+  float _832;
+  float _833;
+  float _834;
+  float _841;
+  float _845;
+  float _846;
+  float _847;
+  bool _848;
+  float _852;
+  float _853;
+  float _854;
+  float _873;
+  float _874;
+  float _875;
+  float _876;
+  float _896;
+  float _897;
+  float _898;
+  float _914;
+  float _915;
+  float _916;
+  float _926;
+  float _927;
+  float _928;
+  float _954;
+  float _955;
+  float _956;
+  float _963;
+  float _964;
+  float _965;
+  float _966;
+  float _967;
+  float _968;
+  float _975;
+  float _976;
+  float _977;
+  float _989;
+  float _990;
+  float _991;
+  float _1014;
+  float _1017;
+  float _1020;
+  float _1082;
+  float _1085;
+  float _1088;
+  float _1098;
+  float _1099;
+  float _1100;
+  float _1176;
+  float _1177;
+  float _1178;
+  float _1181;
+  float _1184;
+  float _1187;
+  float _1190;
+  float _1193;
+  float _1196;
+  float _1198;
+  float _1208;
+  float _1209;
+  float _1211;
+  float _1213;
+  float _1216;
+  float _1231;
+  float _1246;
+  float _1284;
+  float _1285;
+  float _1286;
+  float _1290;
+  float _1295;
+  float _1308;
+  float _1309;
+  float _1310;
+  float _1311;
+  float _1315;
+  float _1326;
+  float _1336;
+  float _1337;
+  float _1338;
+  float _1339;
+  float _1346;
+  float _1349;
+  float _1351;
+  bool _1354;
+  bool _1355;
+  bool _1356;
+  bool _1357;
+  float _1373;
+  float _1388;
+  int _1389;
+  float _1391;
+  float _1392;
+  float _1393;
+  float _1430;
+  float _1431;
+  float _1432;
+  float _1445;
+  float _1446;
+  float _1447;
+  float _1448;
+  float _1471;
+  float _1472;
+  float _1473;
+  float _1474;
+  float _1481;
+  float _1482;
+  float _1490;
+  int _1491;
+  float _1493;
+  float _1495;
+  float _1498;
+  float _1503;
+  float _1512;
+  float _1520;
+  int _1521;
+  float _1523;
+  float _1525;
+  float _1528;
+  float _1533;
+  float _1559;
+  float _1560;
+  float _1567;
+  float _1568;
+  float _1576;
+  int _1577;
+  float _1579;
+  float _1581;
+  float _1584;
+  float _1589;
+  float _1598;
+  float _1606;
+  int _1607;
+  float _1609;
+  float _1611;
+  float _1614;
+  float _1619;
+  float _1633;
+  float _1634;
+  float _1641;
+  float _1642;
+  float _1650;
+  int _1651;
+  float _1653;
+  float _1655;
+  float _1658;
+  float _1663;
+  float _1672;
+  float _1680;
+  int _1681;
+  float _1683;
+  float _1685;
+  float _1688;
+  float _1693;
+  float _1707;
+  float _1708;
+  float _1710;
+  float _1712;
+  float _1715;
+  float _1718;
+  float _1721;
+  float _1734;
+  float _1735;
+  float _1736;
+  float _1739;
+  float _1742;
+  float _1745;
+  float _1767;
+  float _1768;
+  float _1769;
+  float _1794;
+  float _1795;
+  float _1796;
+  float _1862;
+  float _1863;
+  float _1864;
+  float _1867;
+  float _1870;
+  float _1873;
+  float _1876;
+  float _1879;
+  float _1882;
+  float _1884;
+  float _1894;
+  float _1895;
+  float _1897;
+  float _1899;
+  float _1902;
+  float _1917;
+  float _1932;
+  float _1970;
+  float _1971;
+  float _1972;
+  float _1976;
+  float _1981;
+  float _1994;
+  float _1995;
+  float _1996;
+  float _1997;
+  float _2001;
+  float _2012;
+  float _2022;
+  float _2023;
+  float _2024;
+  float _2025;
+  float _2032;
+  float _2035;
+  float _2037;
+  bool _2040;
+  bool _2041;
+  bool _2042;
+  bool _2043;
+  float _2059;
+  float _2074;
+  int _2075;
+  float _2077;
+  float _2078;
+  float _2079;
+  float _2116;
+  float _2117;
+  float _2118;
+  float _2131;
+  float _2132;
+  float _2133;
+  float _2134;
+  float _2157;
+  float _2158;
+  float _2159;
+  float _2160;
+  float _2167;
+  float _2168;
+  float _2176;
+  int _2177;
+  float _2179;
+  float _2181;
+  float _2184;
+  float _2189;
+  float _2198;
+  float _2206;
+  int _2207;
+  float _2209;
+  float _2211;
+  float _2214;
+  float _2219;
+  float _2245;
+  float _2246;
+  float _2253;
+  float _2254;
+  float _2262;
+  int _2263;
+  float _2265;
+  float _2267;
+  float _2270;
+  float _2275;
+  float _2284;
+  float _2292;
+  int _2293;
+  float _2295;
+  float _2297;
+  float _2300;
+  float _2305;
+  float _2331;
+  float _2332;
+  float _2339;
+  float _2340;
+  float _2348;
+  int _2349;
+  float _2351;
+  float _2353;
+  float _2356;
+  float _2361;
+  float _2370;
+  float _2378;
+  int _2379;
+  float _2381;
+  float _2383;
+  float _2386;
+  float _2391;
+  float _2405;
+  float _2406;
+  float _2408;
+  float _2410;
+  float _2413;
+  float _2416;
+  float _2419;
+  float _2432;
+  float _2433;
+  float _2434;
+  float _2437;
+  float _2440;
+  float _2443;
+  float _2465;
+  float _2466;
+  float _2467;
+  float _2492;
+  float _2493;
+  float _2494;
+  float _2539;
+  float _2542;
+  float _2545;
+  float _2564;
+  float _2565;
+  float _2566;
+  float _2613;
+  float _2616;
+  float _2619;
+  float _2632;
+  float _2635;
+  float _2638;
+  float _9[6];
+  float _10[6];
+  float _11[6];
+  float _12[6];
+  float _13[6];
+  float _14[6];
+  float _15[6];
+  float _16[6];
+  float _17[6];
+  float _18[6];
+  float _19[6];
+  float _20[6];
+  _32 = 0.5f / cb0_035x;
+  _37 = cb0_035x + -1.0f;
+  _38 = (cb0_035x * ((cb0_042x * (((float)((uint)SV_DispatchThreadID.x)) + 0.5f)) - _32)) / _37;
+  _39 = (cb0_035x * ((cb0_042y * (((float)((uint)SV_DispatchThreadID.y)) + 0.5f)) - _32)) / _37;
+  _41 = ((float)((uint)SV_DispatchThreadID.z)) / _37;
+  if (!(cb0_041x == 1)) {
+    if (!(cb0_041x == 2)) {
+      if (!(cb0_041x == 3)) {
+        _50 = (cb0_041x == 4);
+        _61 = select(_50, 1.0f, 1.705051064491272f);
+        _62 = select(_50, 0.0f, -0.6217921376228333f);
+        _63 = select(_50, 0.0f, -0.0832589864730835f);
+        _64 = select(_50, 0.0f, -0.13025647401809692f);
+        _65 = select(_50, 1.0f, 1.140804648399353f);
+        _66 = select(_50, 0.0f, -0.010548308491706848f);
+        _67 = select(_50, 0.0f, -0.024003351107239723f);
+        _68 = select(_50, 0.0f, -0.1289689838886261f);
+        _69 = select(_50, 1.0f, 1.1529725790023804f);
+      } else {
+        _61 = 0.6954522132873535f;
+        _62 = 0.14067870378494263f;
+        _63 = 0.16386906802654266f;
+        _64 = 0.044794563204050064f;
+        _65 = 0.8596711158752441f;
+        _66 = 0.0955343171954155f;
+        _67 = -0.005525882821530104f;
+        _68 = 0.004025210160762072f;
+        _69 = 1.0015007257461548f;
+      }
+    } else {
+      _61 = 1.0258246660232544f;
+      _62 = -0.020053181797266006f;
+      _63 = -0.005771636962890625f;
+      _64 = -0.002234415616840124f;
+      _65 = 1.0045864582061768f;
+      _66 = -0.002352118492126465f;
+      _67 = -0.005013350863009691f;
+      _68 = -0.025290070101618767f;
+      _69 = 1.0303035974502563f;
+    }
+  } else {
+    _61 = 1.3792141675949097f;
+    _62 = -0.30886411666870117f;
+    _63 = -0.0703500509262085f;
+    _64 = -0.06933490186929703f;
+    _65 = 1.08229660987854f;
+    _66 = -0.012961871922016144f;
+    _67 = -0.0021590073592960835f;
+    _68 = -0.0454593189060688f;
+    _69 = 1.0476183891296387f;
+  }
+  [branch]
+  if ((uint)cb0_040w > (uint)2) {
+    _80 = (pow(_38, 0.012683313339948654f));
+    _81 = (pow(_39, 0.012683313339948654f));
+    _82 = (pow(_41, 0.012683313339948654f));
+    _127 = (exp2(log2(max(0.0f, (_80 + -0.8359375f)) / (18.8515625f - (_80 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+    _128 = (exp2(log2(max(0.0f, (_81 + -0.8359375f)) / (18.8515625f - (_81 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+    _129 = (exp2(log2(max(0.0f, (_82 + -0.8359375f)) / (18.8515625f - (_82 * 18.6875f))) * 6.277394771575928f) * 100.0f);
+  } else {
+    _127 = ((exp2((_38 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+    _128 = ((exp2((_39 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+    _129 = ((exp2((_41 + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f);
+  }
+  _144 = mad((WorkingColorSpace_128[0].z), _129, mad((WorkingColorSpace_128[0].y), _128, ((WorkingColorSpace_128[0].x) * _127)));
+  _147 = mad((WorkingColorSpace_128[1].z), _129, mad((WorkingColorSpace_128[1].y), _128, ((WorkingColorSpace_128[1].x) * _127)));
+  _150 = mad((WorkingColorSpace_128[2].z), _129, mad((WorkingColorSpace_128[2].y), _128, ((WorkingColorSpace_128[2].x) * _127)));
+  _151 = dot(float3(_144, _147, _150), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _155 = (_144 / _151) + -1.0f;
+  _156 = (_147 / _151) + -1.0f;
+  _157 = (_150 / _151) + -1.0f;
+  // ExpandGamut set to 0
+  _169 = (1.0f - exp2(((_151 * _151) * -4.0f) * 0.f)) * (1.0f - exp2(dot(float3(_155, _156, _157), float3(_155, _156, _157)) * -4.0f));
+  _185 = ((mad(-0.06368321925401688f, _150, mad(-0.3292922377586365f, _147, (_144 * 1.3704125881195068f))) - _144) * _169) + _144;
+  _186 = ((mad(-0.010861365124583244f, _150, mad(1.0970927476882935f, _147, (_144 * -0.08343357592821121f))) - _147) * _169) + _147;
+  _187 = ((mad(1.2036951780319214f, _150, mad(-0.09862580895423889f, _147, (_144 * -0.02579331398010254f))) - _150) * _169) + _150;
+  _188 = dot(float3(_185, _186, _187), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _202 = cb0_019w + cb0_024w;
+  _216 = cb0_018w * cb0_023w;
+  _230 = cb0_017w * cb0_022w;
+  _244 = cb0_016w * cb0_021w;
+  _258 = cb0_015w * cb0_020w;
+  _262 = _185 - _188;
+  _263 = _186 - _188;
+  _264 = _187 - _188;
+  _321 = saturate(_188 / cb0_035w);
+  _325 = (_321 * _321) * (3.0f - (_321 * 2.0f));
+  _326 = 1.0f - _325;
+  _335 = cb0_019w + cb0_034w;
+  _344 = cb0_018w * cb0_033w;
+  _353 = cb0_017w * cb0_032w;
+  _362 = cb0_016w * cb0_031w;
+  _371 = cb0_015w * cb0_030w;
+  _434 = saturate((_188 - cb0_036x) / (cb0_036y - cb0_036x));
+  _438 = (_434 * _434) * (3.0f - (_434 * 2.0f));
+  _447 = cb0_019w + cb0_029w;
+  _456 = cb0_018w * cb0_028w;
+  _465 = cb0_017w * cb0_027w;
+  _474 = cb0_016w * cb0_026w;
+  _483 = cb0_015w * cb0_025w;
+  _541 = _325 - _438;
+  _552 = ((_438 * (((cb0_019x + cb0_034x) + _335) + (((cb0_018x * cb0_033x) * _344) * exp2(log2(exp2(((cb0_016x * cb0_031x) * _362) * log2(max(0.0f, ((((cb0_015x * cb0_030x) * _371) * _262) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_032x) * _353)))))) + (_326 * (((cb0_019x + cb0_024x) + _202) + (((cb0_018x * cb0_023x) * _216) * exp2(log2(exp2(((cb0_016x * cb0_021x) * _244) * log2(max(0.0f, ((((cb0_015x * cb0_020x) * _258) * _262) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_022x) * _230))))))) + ((((cb0_019x + cb0_029x) + _447) + (((cb0_018x * cb0_028x) * _456) * exp2(log2(exp2(((cb0_016x * cb0_026x) * _474) * log2(max(0.0f, ((((cb0_015x * cb0_025x) * _483) * _262) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_027x) * _465))))) * _541);
+  _554 = ((_438 * (((cb0_019y + cb0_034y) + _335) + (((cb0_018y * cb0_033y) * _344) * exp2(log2(exp2(((cb0_016y * cb0_031y) * _362) * log2(max(0.0f, ((((cb0_015y * cb0_030y) * _371) * _263) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_032y) * _353)))))) + (_326 * (((cb0_019y + cb0_024y) + _202) + (((cb0_018y * cb0_023y) * _216) * exp2(log2(exp2(((cb0_016y * cb0_021y) * _244) * log2(max(0.0f, ((((cb0_015y * cb0_020y) * _258) * _263) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_022y) * _230))))))) + ((((cb0_019y + cb0_029y) + _447) + (((cb0_018y * cb0_028y) * _456) * exp2(log2(exp2(((cb0_016y * cb0_026y) * _474) * log2(max(0.0f, ((((cb0_015y * cb0_025y) * _483) * _263) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_027y) * _465))))) * _541);
+  _556 = ((_438 * (((cb0_019z + cb0_034z) + _335) + (((cb0_018z * cb0_033z) * _344) * exp2(log2(exp2(((cb0_016z * cb0_031z) * _362) * log2(max(0.0f, ((((cb0_015z * cb0_030z) * _371) * _264) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_032z) * _353)))))) + (_326 * (((cb0_019z + cb0_024z) + _202) + (((cb0_018z * cb0_023z) * _216) * exp2(log2(exp2(((cb0_016z * cb0_021z) * _244) * log2(max(0.0f, ((((cb0_015z * cb0_020z) * _258) * _264) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_022z) * _230))))))) + ((((cb0_019z + cb0_029z) + _447) + (((cb0_018z * cb0_028z) * _456) * exp2(log2(exp2(((cb0_016z * cb0_026z) * _474) * log2(max(0.0f, ((((cb0_015z * cb0_025z) * _483) * _264) + _188)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_027z) * _465))))) * _541);
+  UECbufferConfig cb_config = CreateCbufferConfig();
+  cb_config.ue_filmblackclip = cb0_038x;
+  cb_config.ue_filmtoe = cb0_037z;
+  cb_config.ue_filmshoulder = cb0_037w;
+  cb_config.ue_filmslope = cb0_037y;
+  cb_config.ue_filmwhiteclip = cb0_038y;
+  cb_config.ue_tonecurveammount = cb0_037x;
+  cb_config.ue_mappingpolynomial = float3(cb0_039x, cb0_039y, cb0_039z);
+  cb_config.ue_overlaycolor = float4(cb0_013x, cb0_013y, cb0_013z, cb0_013w);
+  cb_config.ue_bluecorrection = cb0_036z;
+  cb_config.ue_colorscale = float3(cb0_014x, cb0_014y, cb0_014z);
+
+  float4 output = ProcessLutbuilder(float3(_552, _554, _556), cb_config, u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))], cb0_040w);
+  u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))] = output;
+  return;
+
+  _592 = ((mad(0.061360642313957214f, _556, mad(-4.540197551250458e-09f, _554, (_552 * 0.9386394023895264f))) - _552) * cb0_036z) + _552;
+  _593 = ((mad(0.169205904006958f, _556, mad(0.8307942152023315f, _554, (_552 * 6.775371730327606e-08f))) - _554) * cb0_036z) + _554;
+  _594 = (mad(-2.3283064365386963e-10f, _554, (_552 * -9.313225746154785e-10f)) * cb0_036z) + _556;
+  _597 = mad(0.16386905312538147f, _594, mad(0.14067868888378143f, _593, (_592 * 0.6954522132873535f)));
+  _600 = mad(0.0955343246459961f, _594, mad(0.8596711158752441f, _593, (_592 * 0.044794581830501556f)));
+  _603 = mad(1.0015007257461548f, _594, mad(0.004025210160762072f, _593, (_592 * -0.005525882821530104f)));
+  _607 = max(max(_597, _600), _603);
+  _612 = (max(_607, 1.000000013351432e-10f) - max(min(min(_597, _600), _603), 1.000000013351432e-10f)) / max(_607, 0.009999999776482582f);
+  _625 = ((_600 + _597) + _603) + (sqrt((((_603 - _600) * _603) + ((_600 - _597) * _600)) + ((_597 - _603) * _597)) * 1.75f);
+  _626 = _625 * 0.3333333432674408f;
+  _627 = _612 + -0.4000000059604645f;
+  _628 = _627 * 5.0f;
+  _632 = max((1.0f - abs(_627 * 2.5f)), 0.0f);
+  _643 = ((float((int)(((int)(uint)((int)(_628 > 0.0f))) - ((int)(uint)((int)(_628 < 0.0f))))) * (1.0f - (_632 * _632))) + 1.0f) * 0.02500000037252903f;
+  if (!(_626 <= 0.0533333346247673f)) {
+    if (!(_626 >= 0.1599999964237213f)) {
+      _652 = (((0.23999999463558197f / _625) + -0.5f) * _643);
+    } else {
+      _652 = 0.0f;
+    }
+  } else {
+    _652 = _643;
+  }
+  _653 = _652 + 1.0f;
+  _654 = _653 * _597;
+  _655 = _653 * _600;
+  _656 = _653 * _603;
+  if (!((_654 == _655) && (_655 == _656))) {
+    _663 = ((_654 * 2.0f) - _655) - _656;
+    _666 = ((_600 - _603) * 1.7320507764816284f) * _653;
+    _668 = atan(_666 / _663);
+    _671 = (_663 < 0.0f);
+    _672 = (_663 == 0.0f);
+    _673 = (_666 >= 0.0f);
+    _674 = (_666 < 0.0f);
+    _685 = select((_673 && _672), 90.0f, select((_674 && _672), -90.0f, (select((_674 && _671), (_668 + -3.1415927410125732f), select((_673 && _671), (_668 + 3.1415927410125732f), _668)) * 57.2957763671875f)));
+  } else {
+    _685 = 0.0f;
+  }
+  _690 = min(max(select((_685 < 0.0f), (_685 + 360.0f), _685), 0.0f), 360.0f);
+  if (_690 < -180.0f) {
+    _699 = (_690 + 360.0f);
+  } else {
+    if (_690 > 180.0f) {
+      _699 = (_690 + -360.0f);
+    } else {
+      _699 = _690;
+    }
+  }
+  _703 = saturate(1.0f - abs(_699 * 0.014814814552664757f));
+  _707 = (_703 * _703) * (3.0f - (_703 * 2.0f));
+  _713 = ((_707 * _707) * ((_612 * 0.18000000715255737f) * (0.029999999329447746f - _654))) + _654;
+  _723 = max(0.0f, mad(-0.21492856740951538f, _656, mad(-0.2365107536315918f, _655, (_713 * 1.4514392614364624f))));
+  _724 = max(0.0f, mad(-0.09967592358589172f, _656, mad(1.17622971534729f, _655, (_713 * -0.07655377686023712f))));
+  _725 = max(0.0f, mad(0.9977163076400757f, _656, mad(-0.006032449658960104f, _655, (_713 * 0.008316148072481155f))));
+  _726 = dot(float3(_723, _724, _725), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _741 = (cb0_038x + 1.0f) - cb0_037z;
+  _743 = cb0_038y + 1.0f;
+  _745 = _743 - cb0_037w;
+  if (cb0_037z > 0.800000011920929f) {
+    _763 = (((0.8199999928474426f - cb0_037z) / cb0_037y) + -0.7447274923324585f);
+  } else {
+    _754 = (cb0_038x + 0.18000000715255737f) / _741;
+    _763 = (-0.7447274923324585f - ((log2(_754 / (2.0f - _754)) * 0.3465735912322998f) * (_741 / cb0_037y)));
+  }
+  _766 = ((1.0f - cb0_037z) / cb0_037y) - _763;
+  _768 = (cb0_037w / cb0_037y) - _766;
+  _772 = log2(lerp(_726, _723, 0.9599999785423279f)) * 0.3010300099849701f;
+  _773 = log2(lerp(_726, _724, 0.9599999785423279f)) * 0.3010300099849701f;
+  _774 = log2(lerp(_726, _725, 0.9599999785423279f)) * 0.3010300099849701f;
+  _778 = cb0_037y * (_772 + _766);
+  _779 = cb0_037y * (_773 + _766);
+  _780 = cb0_037y * (_774 + _766);
+  _781 = _741 * 2.0f;
+  _783 = (cb0_037y * -2.0f) / _741;
+  _784 = _772 - _763;
+  _785 = _773 - _763;
+  _786 = _774 - _763;
+  _805 = _745 * 2.0f;
+  _807 = (cb0_037y * 2.0f) / _745;
+  _832 = select((_772 < _763), ((_781 / (exp2((_784 * 1.4426950216293335f) * _783) + 1.0f)) - cb0_038x), _778);
+  _833 = select((_773 < _763), ((_781 / (exp2((_785 * 1.4426950216293335f) * _783) + 1.0f)) - cb0_038x), _779);
+  _834 = select((_774 < _763), ((_781 / (exp2((_786 * 1.4426950216293335f) * _783) + 1.0f)) - cb0_038x), _780);
+  _841 = _768 - _763;
+  _845 = saturate(_784 / _841);
+  _846 = saturate(_785 / _841);
+  _847 = saturate(_786 / _841);
+  _848 = (_768 < _763);
+  _852 = select(_848, (1.0f - _845), _845);
+  _853 = select(_848, (1.0f - _846), _846);
+  _854 = select(_848, (1.0f - _847), _847);
+  _873 = (((_852 * _852) * (select((_772 > _768), (_743 - (_805 / (exp2(((_772 - _768) * 1.4426950216293335f) * _807) + 1.0f))), _778) - _832)) * (3.0f - (_852 * 2.0f))) + _832;
+  _874 = (((_853 * _853) * (select((_773 > _768), (_743 - (_805 / (exp2(((_773 - _768) * 1.4426950216293335f) * _807) + 1.0f))), _779) - _833)) * (3.0f - (_853 * 2.0f))) + _833;
+  _875 = (((_854 * _854) * (select((_774 > _768), (_743 - (_805 / (exp2(((_774 - _768) * 1.4426950216293335f) * _807) + 1.0f))), _780) - _834)) * (3.0f - (_854 * 2.0f))) + _834;
+  _876 = dot(float3(_873, _874, _875), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _896 = (cb0_037x * (max(0.0f, (lerp(_876, _873, 0.9300000071525574f))) - _592)) + _592;
+  _897 = (cb0_037x * (max(0.0f, (lerp(_876, _874, 0.9300000071525574f))) - _593)) + _593;
+  _898 = (cb0_037x * (max(0.0f, (lerp(_876, _875, 0.9300000071525574f))) - _594)) + _594;
+  _914 = ((mad(-0.06537103652954102f, _898, mad(1.451815478503704e-06f, _897, (_896 * 1.065374732017517f))) - _896) * cb0_036z) + _896;
+  _915 = ((mad(-0.20366770029067993f, _898, mad(1.2036634683609009f, _897, (_896 * -2.57161445915699e-07f))) - _897) * cb0_036z) + _897;
+  _916 = ((mad(0.9999996423721313f, _898, mad(2.0954757928848267e-08f, _897, (_896 * 1.862645149230957e-08f))) - _898) * cb0_036z) + _898;
+  _926 = max(0.0f, mad((WorkingColorSpace_192[0].z), _916, mad((WorkingColorSpace_192[0].y), _915, ((WorkingColorSpace_192[0].x) * _914))));
+  _927 = max(0.0f, mad((WorkingColorSpace_192[1].z), _916, mad((WorkingColorSpace_192[1].y), _915, ((WorkingColorSpace_192[1].x) * _914))));
+  _928 = max(0.0f, mad((WorkingColorSpace_192[2].z), _916, mad((WorkingColorSpace_192[2].y), _915, ((WorkingColorSpace_192[2].x) * _914))));
+  _954 = cb0_014x * (((cb0_039y + (cb0_039x * _926)) * _926) + cb0_039z);
+  _955 = cb0_014y * (((cb0_039y + (cb0_039x * _927)) * _927) + cb0_039z);
+  _956 = cb0_014z * (((cb0_039y + (cb0_039x * _928)) * _928) + cb0_039z);
+  _963 = ((cb0_013x - _954) * cb0_013w) + _954;
+  _964 = ((cb0_013y - _955) * cb0_013w) + _955;
+  _965 = ((cb0_013z - _956) * cb0_013w) + _956;
+  _966 = cb0_014x * mad((WorkingColorSpace_192[0].z), _556, mad((WorkingColorSpace_192[0].y), _554, (_552 * (WorkingColorSpace_192[0].x))));
+  _967 = cb0_014y * mad((WorkingColorSpace_192[1].z), _556, mad((WorkingColorSpace_192[1].y), _554, ((WorkingColorSpace_192[1].x) * _552)));
+  _968 = cb0_014z * mad((WorkingColorSpace_192[2].z), _556, mad((WorkingColorSpace_192[2].y), _554, ((WorkingColorSpace_192[2].x) * _552)));
+  _975 = ((cb0_013x - _966) * cb0_013w) + _966;
+  _976 = ((cb0_013y - _967) * cb0_013w) + _967;
+  _977 = ((cb0_013z - _968) * cb0_013w) + _968;
+  _989 = exp2(log2(max(0.0f, _963)) * cb0_040y);
+  _990 = exp2(log2(max(0.0f, _964)) * cb0_040y);
+  _991 = exp2(log2(max(0.0f, _965)) * cb0_040y);
+  [branch]
+  if (cb0_040w == 0) {
+    do {
+      _1031 = _989;
+      _1032 = _990;
+      _1033 = _991;
+      if (WorkingColorSpace_320 == 0) {
+        _1014 = mad((WorkingColorSpace_128[0].z), _991, mad((WorkingColorSpace_128[0].y), _990, ((WorkingColorSpace_128[0].x) * _989)));
+        _1017 = mad((WorkingColorSpace_128[1].z), _991, mad((WorkingColorSpace_128[1].y), _990, ((WorkingColorSpace_128[1].x) * _989)));
+        _1020 = mad((WorkingColorSpace_128[2].z), _991, mad((WorkingColorSpace_128[2].y), _990, ((WorkingColorSpace_128[2].x) * _989)));
+        _1031 = mad(_63, _1020, mad(_62, _1017, (_1014 * _61)));
+        _1032 = mad(_66, _1020, mad(_65, _1017, (_1014 * _64)));
+        _1033 = mad(_69, _1020, mad(_68, _1017, (_1014 * _67)));
+      }
+      do {
+        if (_1031 < 0.0031306699384003878f) {
+          _1044 = (_1031 * 12.920000076293945f);
+        } else {
+          _1044 = (((pow(_1031, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+        }
+        do {
+          if (_1032 < 0.0031306699384003878f) {
+            _1055 = (_1032 * 12.920000076293945f);
+          } else {
+            _1055 = (((pow(_1032, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+          }
+          if (_1033 < 0.0031306699384003878f) {
+            _2659 = _1044;
+            _2660 = _1055;
+            _2661 = (_1033 * 12.920000076293945f);
+          } else {
+            _2659 = _1044;
+            _2660 = _1055;
+            _2661 = (((pow(_1033, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+          }
+        } while (false);
+      } while (false);
+    } while (false);
+  } else {
+    if (cb0_040w == 1) {
+      _1082 = mad((WorkingColorSpace_128[0].z), _991, mad((WorkingColorSpace_128[0].y), _990, ((WorkingColorSpace_128[0].x) * _989)));
+      _1085 = mad((WorkingColorSpace_128[1].z), _991, mad((WorkingColorSpace_128[1].y), _990, ((WorkingColorSpace_128[1].x) * _989)));
+      _1088 = mad((WorkingColorSpace_128[2].z), _991, mad((WorkingColorSpace_128[2].y), _990, ((WorkingColorSpace_128[2].x) * _989)));
+      _1098 = max(6.103519990574569e-05f, mad(_63, _1088, mad(_62, _1085, (_1082 * _61))));
+      _1099 = max(6.103519990574569e-05f, mad(_66, _1088, mad(_65, _1085, (_1082 * _64))));
+      _1100 = max(6.103519990574569e-05f, mad(_69, _1088, mad(_68, _1085, (_1082 * _67))));
+      _2659 = min((_1098 * 4.5f), ((exp2(log2(max(_1098, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+      _2660 = min((_1099 * 4.5f), ((exp2(log2(max(_1099, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+      _2661 = min((_1100 * 4.5f), ((exp2(log2(max(_1100, 0.017999999225139618f)) * 0.44999998807907104f) * 1.0989999771118164f) + -0.0989999994635582f));
+    } else {
+      if ((cb0_040w == 3) || (cb0_040w == 5)) {
+        _9[0] = cb0_010x;
+        _9[1] = cb0_010y;
+        _9[2] = cb0_010z;
+        _9[3] = cb0_010w;
+        _9[4] = cb0_012x;
+        _9[5] = cb0_012x;
+        _10[0] = cb0_011x;
+        _10[1] = cb0_011y;
+        _10[2] = cb0_011z;
+        _10[3] = cb0_011w;
+        _10[4] = cb0_012y;
+        _10[5] = cb0_012y;
+        _1176 = cb0_012z * _975;
+        _1177 = cb0_012z * _976;
+        _1178 = cb0_012z * _977;
+        _1181 = mad((WorkingColorSpace_256[0].z), _1178, mad((WorkingColorSpace_256[0].y), _1177, ((WorkingColorSpace_256[0].x) * _1176)));
+        _1184 = mad((WorkingColorSpace_256[1].z), _1178, mad((WorkingColorSpace_256[1].y), _1177, ((WorkingColorSpace_256[1].x) * _1176)));
+        _1187 = mad((WorkingColorSpace_256[2].z), _1178, mad((WorkingColorSpace_256[2].y), _1177, ((WorkingColorSpace_256[2].x) * _1176)));
+        _1190 = mad(-0.21492856740951538f, _1187, mad(-0.2365107536315918f, _1184, (_1181 * 1.4514392614364624f)));
+        _1193 = mad(-0.09967592358589172f, _1187, mad(1.17622971534729f, _1184, (_1181 * -0.07655377686023712f)));
+        _1196 = mad(0.9977163076400757f, _1187, mad(-0.006032449658960104f, _1184, (_1181 * 0.008316148072481155f)));
+        _1198 = max(_1190, max(_1193, _1196));
+        do {
+          _1266 = _1190;
+          _1267 = _1193;
+          _1268 = _1196;
+          if (!(_1198 < 1.000000013351432e-10f)) {
+            if (!(((_1181 < 0.0f) || (_1184 < 0.0f)) || (_1187 < 0.0f))) {
+              _1208 = abs(_1198);
+              _1209 = (_1198 - _1190) / _1208;
+              _1211 = (_1198 - _1193) / _1208;
+              _1213 = (_1198 - _1196) / _1208;
+              do {
+                _1228 = _1209;
+                if (!(_1209 < 0.8149999976158142f)) {
+                  _1216 = _1209 + -0.8149999976158142f;
+                  _1228 = ((_1216 / exp2(log2(exp2(log2(_1216 * 3.0552830696105957f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8149999976158142f);
+                }
+                do {
+                  _1243 = _1211;
+                  if (!(_1211 < 0.8029999732971191f)) {
+                    _1231 = _1211 + -0.8029999732971191f;
+                    _1243 = ((_1231 / exp2(log2(exp2(log2(_1231 * 3.4972610473632812f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8029999732971191f);
+                  }
+                  do {
+                    _1258 = _1213;
+                    if (!(_1213 < 0.8799999952316284f)) {
+                      _1246 = _1213 + -0.8799999952316284f;
+                      _1258 = ((_1246 / exp2(log2(exp2(log2(_1246 * 6.810994625091553f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8799999952316284f);
+                    }
+                    _1266 = (_1198 - (_1208 * _1228));
+                    _1267 = (_1198 - (_1208 * _1243));
+                    _1268 = (_1198 - (_1208 * _1258));
+                  } while (false);
+                } while (false);
+              } while (false);
+            } else {
+              _1266 = _1190;
+              _1267 = _1193;
+              _1268 = _1196;
+            }
+          }
+          _1284 = ((mad(0.16386906802654266f, _1268, mad(0.14067870378494263f, _1267, (_1266 * 0.6954522132873535f))) - _1181) * cb0_012w) + _1181;
+          _1285 = ((mad(0.0955343171954155f, _1268, mad(0.8596711158752441f, _1267, (_1266 * 0.044794563204050064f))) - _1184) * cb0_012w) + _1184;
+          _1286 = ((mad(1.0015007257461548f, _1268, mad(0.004025210160762072f, _1267, (_1266 * -0.005525882821530104f))) - _1187) * cb0_012w) + _1187;
+          _1290 = max(max(_1284, _1285), _1286);
+          _1295 = (max(_1290, 1.000000013351432e-10f) - max(min(min(_1284, _1285), _1286), 1.000000013351432e-10f)) / max(_1290, 0.009999999776482582f);
+          _1308 = ((_1285 + _1284) + _1286) + (sqrt((((_1286 - _1285) * _1286) + ((_1285 - _1284) * _1285)) + ((_1284 - _1286) * _1284)) * 1.75f);
+          _1309 = _1308 * 0.3333333432674408f;
+          _1310 = _1295 + -0.4000000059604645f;
+          _1311 = _1310 * 5.0f;
+          _1315 = max((1.0f - abs(_1310 * 2.5f)), 0.0f);
+          _1326 = ((float((int)(((int)(uint)((int)(_1311 > 0.0f))) - ((int)(uint)((int)(_1311 < 0.0f))))) * (1.0f - (_1315 * _1315))) + 1.0f) * 0.02500000037252903f;
+          do {
+            _1335 = _1326;
+            if (!(_1309 <= 0.0533333346247673f)) {
+              if (!(_1309 >= 0.1599999964237213f)) {
+                _1335 = (((0.23999999463558197f / _1308) + -0.5f) * _1326);
+              } else {
+                _1335 = 0.0f;
+              }
+            }
+            _1336 = _1335 + 1.0f;
+            _1337 = _1336 * _1284;
+            _1338 = _1336 * _1285;
+            _1339 = _1336 * _1286;
+            do {
+              _1368 = 0.0f;
+              if (!((_1337 == _1338) && (_1338 == _1339))) {
+                _1346 = ((_1337 * 2.0f) - _1338) - _1339;
+                _1349 = ((_1285 - _1286) * 1.7320507764816284f) * _1336;
+                _1351 = atan(_1349 / _1346);
+                _1354 = (_1346 < 0.0f);
+                _1355 = (_1346 == 0.0f);
+                _1356 = (_1349 >= 0.0f);
+                _1357 = (_1349 < 0.0f);
+                _1368 = select((_1356 && _1355), 90.0f, select((_1357 && _1355), -90.0f, (select((_1357 && _1354), (_1351 + -3.1415927410125732f), select((_1356 && _1354), (_1351 + 3.1415927410125732f), _1351)) * 57.2957763671875f)));
+              }
+              _1373 = min(max(select((_1368 < 0.0f), (_1368 + 360.0f), _1368), 0.0f), 360.0f);
+              do {
+                if (_1373 < -180.0f) {
+                  _1382 = (_1373 + 360.0f);
+                } else {
+                  if (_1373 > 180.0f) {
+                    _1382 = (_1373 + -360.0f);
+                  } else {
+                    _1382 = _1373;
+                  }
+                }
+                do {
+                  _1421 = 0.0f;
+                  if ((_1382 > -67.5f) && (_1382 < 67.5f)) {
+                    _1388 = (_1382 + 67.5f) * 0.029629629105329514f;
+                    _1389 = int(_1388);
+                    _1391 = _1388 - float((int)(_1389));
+                    _1392 = _1391 * _1391;
+                    _1393 = _1392 * _1391;
+                    if (_1389 == 3) {
+                      _1421 = (((0.1666666716337204f - (_1391 * 0.5f)) + (_1392 * 0.5f)) - (_1393 * 0.1666666716337204f));
+                    } else {
+                      if (_1389 == 2) {
+                        _1421 = ((0.6666666865348816f - _1392) + (_1393 * 0.5f));
+                      } else {
+                        if (_1389 == 1) {
+                          _1421 = (((_1393 * -0.5f) + 0.1666666716337204f) + ((_1392 + _1391) * 0.5f));
+                        } else {
+                          _1421 = select((_1389 == 0), (_1393 * 0.1666666716337204f), 0.0f);
+                        }
+                      }
+                    }
+                  }
+                  _1430 = min(max(((((_1295 * 0.27000001072883606f) * (0.029999999329447746f - _1337)) * _1421) + _1337), 0.0f), 65535.0f);
+                  _1431 = min(max(_1338, 0.0f), 65535.0f);
+                  _1432 = min(max(_1339, 0.0f), 65535.0f);
+                  _1445 = min(max(mad(-0.21492856740951538f, _1432, mad(-0.2365107536315918f, _1431, (_1430 * 1.4514392614364624f))), 0.0f), 65504.0f);
+                  _1446 = min(max(mad(-0.09967592358589172f, _1432, mad(1.17622971534729f, _1431, (_1430 * -0.07655377686023712f))), 0.0f), 65504.0f);
+                  _1447 = min(max(mad(0.9977163076400757f, _1432, mad(-0.006032449658960104f, _1431, (_1430 * 0.008316148072481155f))), 0.0f), 65504.0f);
+                  _1448 = dot(float3(_1445, _1446, _1447), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+                  _17[0] = cb0_010x;
+                  _17[1] = cb0_010y;
+                  _17[2] = cb0_010z;
+                  _17[3] = cb0_010w;
+                  _17[4] = cb0_012x;
+                  _17[5] = cb0_012x;
+                  _18[0] = cb0_011x;
+                  _18[1] = cb0_011y;
+                  _18[2] = cb0_011z;
+                  _18[3] = cb0_011w;
+                  _18[4] = cb0_012y;
+                  _18[5] = cb0_012y;
+                  _1471 = log2(max((lerp(_1448, _1445, 0.9599999785423279f)), 1.000000013351432e-10f));
+                  _1472 = _1471 * 0.3010300099849701f;
+                  _1473 = log2(cb0_008x);
+                  _1474 = _1473 * 0.3010300099849701f;
+                  do {
+                    if (!(!(_1472 <= _1474))) {
+                      _1543 = (log2(cb0_008y) * 0.3010300099849701f);
+                    } else {
+                      _1481 = log2(cb0_009x);
+                      _1482 = _1481 * 0.3010300099849701f;
+                      if ((_1472 > _1474) && (_1472 < _1482)) {
+                        _1490 = ((_1471 - _1473) * 0.9030900001525879f) / ((_1481 - _1473) * 0.3010300099849701f);
+                        _1491 = int(_1490);
+                        _1493 = _1490 - float((int)(_1491));
+                        _1495 = _17[min((uint)(_1491), 5u)];
+                        _1498 = _17[min((uint)((_1491 + 1)), 5u)];
+                        _1503 = _1495 * 0.5f;
+                        _1543 = dot(float3((_1493 * _1493), _1493, 1.0f), float3(mad((_17[min((uint)((_1491 + 2)), 5u)]), 0.5f, mad(_1498, -1.0f, _1503)), (_1498 - _1495), mad(_1498, 0.5f, _1503)));
+                      } else {
+                        if (!(!(_1472 >= _1482))) {
+                          _1512 = log2(cb0_008z);
+                          if (_1472 < (_1512 * 0.3010300099849701f)) {
+                            _1520 = ((_1471 - _1481) * 0.9030900001525879f) / ((_1512 - _1481) * 0.3010300099849701f);
+                            _1521 = int(_1520);
+                            _1523 = _1520 - float((int)(_1521));
+                            _1525 = _18[min((uint)(_1521), 5u)];
+                            _1528 = _18[min((uint)((_1521 + 1)), 5u)];
+                            _1533 = _1525 * 0.5f;
+                            _1543 = dot(float3((_1523 * _1523), _1523, 1.0f), float3(mad((_18[min((uint)((_1521 + 2)), 5u)]), 0.5f, mad(_1528, -1.0f, _1533)), (_1528 - _1525), mad(_1528, 0.5f, _1533)));
+                          } else {
+                            _1543 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        } else {
+                          _1543 = (log2(cb0_008w) * 0.3010300099849701f);
+                        }
+                      }
+                    }
+                    _19[0] = cb0_010x;
+                    _19[1] = cb0_010y;
+                    _19[2] = cb0_010z;
+                    _19[3] = cb0_010w;
+                    _19[4] = cb0_012x;
+                    _19[5] = cb0_012x;
+                    _20[0] = cb0_011x;
+                    _20[1] = cb0_011y;
+                    _20[2] = cb0_011z;
+                    _20[3] = cb0_011w;
+                    _20[4] = cb0_012y;
+                    _20[5] = cb0_012y;
+                    _1559 = log2(max((lerp(_1448, _1446, 0.9599999785423279f)), 1.000000013351432e-10f));
+                    _1560 = _1559 * 0.3010300099849701f;
+                    do {
+                      if (!(!(_1560 <= _1474))) {
+                        _1629 = (log2(cb0_008y) * 0.3010300099849701f);
+                      } else {
+                        _1567 = log2(cb0_009x);
+                        _1568 = _1567 * 0.3010300099849701f;
+                        if ((_1560 > _1474) && (_1560 < _1568)) {
+                          _1576 = ((_1559 - _1473) * 0.9030900001525879f) / ((_1567 - _1473) * 0.3010300099849701f);
+                          _1577 = int(_1576);
+                          _1579 = _1576 - float((int)(_1577));
+                          _1581 = _19[min((uint)(_1577), 5u)];
+                          _1584 = _19[min((uint)((_1577 + 1)), 5u)];
+                          _1589 = _1581 * 0.5f;
+                          _1629 = dot(float3((_1579 * _1579), _1579, 1.0f), float3(mad((_19[min((uint)((_1577 + 2)), 5u)]), 0.5f, mad(_1584, -1.0f, _1589)), (_1584 - _1581), mad(_1584, 0.5f, _1589)));
+                        } else {
+                          if (!(!(_1560 >= _1568))) {
+                            _1598 = log2(cb0_008z);
+                            if (_1560 < (_1598 * 0.3010300099849701f)) {
+                              _1606 = ((_1559 - _1567) * 0.9030900001525879f) / ((_1598 - _1567) * 0.3010300099849701f);
+                              _1607 = int(_1606);
+                              _1609 = _1606 - float((int)(_1607));
+                              _1611 = _20[min((uint)(_1607), 5u)];
+                              _1614 = _20[min((uint)((_1607 + 1)), 5u)];
+                              _1619 = _1611 * 0.5f;
+                              _1629 = dot(float3((_1609 * _1609), _1609, 1.0f), float3(mad((_20[min((uint)((_1607 + 2)), 5u)]), 0.5f, mad(_1614, -1.0f, _1619)), (_1614 - _1611), mad(_1614, 0.5f, _1619)));
+                            } else {
+                              _1629 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          } else {
+                            _1629 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        }
+                      }
+                      _1633 = log2(max((lerp(_1448, _1447, 0.9599999785423279f)), 1.000000013351432e-10f));
+                      _1634 = _1633 * 0.3010300099849701f;
+                      do {
+                        if (!(!(_1634 <= _1474))) {
+                          _1703 = (log2(cb0_008y) * 0.3010300099849701f);
+                        } else {
+                          _1641 = log2(cb0_009x);
+                          _1642 = _1641 * 0.3010300099849701f;
+                          if ((_1634 > _1474) && (_1634 < _1642)) {
+                            _1650 = ((_1633 - _1473) * 0.9030900001525879f) / ((_1641 - _1473) * 0.3010300099849701f);
+                            _1651 = int(_1650);
+                            _1653 = _1650 - float((int)(_1651));
+                            _1655 = _9[min((uint)(_1651), 5u)];
+                            _1658 = _9[min((uint)((_1651 + 1)), 5u)];
+                            _1663 = _1655 * 0.5f;
+                            _1703 = dot(float3((_1653 * _1653), _1653, 1.0f), float3(mad((_9[min((uint)((_1651 + 2)), 5u)]), 0.5f, mad(_1658, -1.0f, _1663)), (_1658 - _1655), mad(_1658, 0.5f, _1663)));
+                          } else {
+                            if (!(!(_1634 >= _1642))) {
+                              _1672 = log2(cb0_008z);
+                              if (_1634 < (_1672 * 0.3010300099849701f)) {
+                                _1680 = ((_1633 - _1641) * 0.9030900001525879f) / ((_1672 - _1641) * 0.3010300099849701f);
+                                _1681 = int(_1680);
+                                _1683 = _1680 - float((int)(_1681));
+                                _1685 = _10[min((uint)(_1681), 5u)];
+                                _1688 = _10[min((uint)((_1681 + 1)), 5u)];
+                                _1693 = _1685 * 0.5f;
+                                _1703 = dot(float3((_1683 * _1683), _1683, 1.0f), float3(mad((_10[min((uint)((_1681 + 2)), 5u)]), 0.5f, mad(_1688, -1.0f, _1693)), (_1688 - _1685), mad(_1688, 0.5f, _1693)));
+                              } else {
+                                _1703 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            } else {
+                              _1703 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          }
+                        }
+                        _1707 = cb0_008w - cb0_008y;
+                        _1708 = (exp2(_1543 * 3.321928024291992f) - cb0_008y) / _1707;
+                        _1710 = (exp2(_1629 * 3.321928024291992f) - cb0_008y) / _1707;
+                        _1712 = (exp2(_1703 * 3.321928024291992f) - cb0_008y) / _1707;
+                        _1715 = mad(0.15618768334388733f, _1712, mad(0.13400420546531677f, _1710, (_1708 * 0.6624541878700256f)));
+                        _1718 = mad(0.053689517080783844f, _1712, mad(0.6740817427635193f, _1710, (_1708 * 0.2722287178039551f)));
+                        _1721 = mad(1.0103391408920288f, _1712, mad(0.00406073359772563f, _1710, (_1708 * -0.005574649665504694f)));
+                        _1734 = min(max(mad(-0.23642469942569733f, _1721, mad(-0.32480329275131226f, _1718, (_1715 * 1.6410233974456787f))), 0.0f), 1.0f);
+                        _1735 = min(max(mad(0.016756348311901093f, _1721, mad(1.6153316497802734f, _1718, (_1715 * -0.663662850856781f))), 0.0f), 1.0f);
+                        _1736 = min(max(mad(0.9883948564529419f, _1721, mad(-0.008284442126750946f, _1718, (_1715 * 0.011721894145011902f))), 0.0f), 1.0f);
+                        _1739 = mad(0.15618768334388733f, _1736, mad(0.13400420546531677f, _1735, (_1734 * 0.6624541878700256f)));
+                        _1742 = mad(0.053689517080783844f, _1736, mad(0.6740817427635193f, _1735, (_1734 * 0.2722287178039551f)));
+                        _1745 = mad(1.0103391408920288f, _1736, mad(0.00406073359772563f, _1735, (_1734 * -0.005574649665504694f)));
+                        _1767 = min(max((min(max(mad(-0.23642469942569733f, _1745, mad(-0.32480329275131226f, _1742, (_1739 * 1.6410233974456787f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        _1768 = min(max((min(max(mad(0.016756348311901093f, _1745, mad(1.6153316497802734f, _1742, (_1739 * -0.663662850856781f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        _1769 = min(max((min(max(mad(0.9883948564529419f, _1745, mad(-0.008284442126750946f, _1742, (_1739 * 0.011721894145011902f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                        do {
+                          _1782 = _1767;
+                          _1783 = _1768;
+                          _1784 = _1769;
+                          if (!(cb0_040w == 5)) {
+                            _1782 = mad(_63, _1769, mad(_62, _1768, (_1767 * _61)));
+                            _1783 = mad(_66, _1769, mad(_65, _1768, (_1767 * _64)));
+                            _1784 = mad(_69, _1769, mad(_68, _1768, (_1767 * _67)));
+                          }
+                          _1794 = exp2(log2(_1782 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _1795 = exp2(log2(_1783 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _1796 = exp2(log2(_1784 * 9.999999747378752e-05f) * 0.1593017578125f);
+                          _2659 = exp2(log2((1.0f / ((_1794 * 18.6875f) + 1.0f)) * ((_1794 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          _2660 = exp2(log2((1.0f / ((_1795 * 18.6875f) + 1.0f)) * ((_1795 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          _2661 = exp2(log2((1.0f / ((_1796 * 18.6875f) + 1.0f)) * ((_1796 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                        } while (false);
+                      } while (false);
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } while (false);
+            } while (false);
+          } while (false);
+        } while (false);
+      } else {
+        if ((cb0_040w & -3) == 4) {
+          _1862 = cb0_012z * _975;
+          _1863 = cb0_012z * _976;
+          _1864 = cb0_012z * _977;
+          _1867 = mad((WorkingColorSpace_256[0].z), _1864, mad((WorkingColorSpace_256[0].y), _1863, ((WorkingColorSpace_256[0].x) * _1862)));
+          _1870 = mad((WorkingColorSpace_256[1].z), _1864, mad((WorkingColorSpace_256[1].y), _1863, ((WorkingColorSpace_256[1].x) * _1862)));
+          _1873 = mad((WorkingColorSpace_256[2].z), _1864, mad((WorkingColorSpace_256[2].y), _1863, ((WorkingColorSpace_256[2].x) * _1862)));
+          _1876 = mad(-0.21492856740951538f, _1873, mad(-0.2365107536315918f, _1870, (_1867 * 1.4514392614364624f)));
+          _1879 = mad(-0.09967592358589172f, _1873, mad(1.17622971534729f, _1870, (_1867 * -0.07655377686023712f)));
+          _1882 = mad(0.9977163076400757f, _1873, mad(-0.006032449658960104f, _1870, (_1867 * 0.008316148072481155f)));
+          _1884 = max(_1876, max(_1879, _1882));
+          do {
+            _1952 = _1876;
+            _1953 = _1879;
+            _1954 = _1882;
+            if (!(_1884 < 1.000000013351432e-10f)) {
+              if (!(((_1867 < 0.0f) || (_1870 < 0.0f)) || (_1873 < 0.0f))) {
+                _1894 = abs(_1884);
+                _1895 = (_1884 - _1876) / _1894;
+                _1897 = (_1884 - _1879) / _1894;
+                _1899 = (_1884 - _1882) / _1894;
+                do {
+                  _1914 = _1895;
+                  if (!(_1895 < 0.8149999976158142f)) {
+                    _1902 = _1895 + -0.8149999976158142f;
+                    _1914 = ((_1902 / exp2(log2(exp2(log2(_1902 * 3.0552830696105957f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8149999976158142f);
+                  }
+                  do {
+                    _1929 = _1897;
+                    if (!(_1897 < 0.8029999732971191f)) {
+                      _1917 = _1897 + -0.8029999732971191f;
+                      _1929 = ((_1917 / exp2(log2(exp2(log2(_1917 * 3.4972610473632812f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8029999732971191f);
+                    }
+                    do {
+                      _1944 = _1899;
+                      if (!(_1899 < 0.8799999952316284f)) {
+                        _1932 = _1899 + -0.8799999952316284f;
+                        _1944 = ((_1932 / exp2(log2(exp2(log2(_1932 * 6.810994625091553f) * 1.2000000476837158f) + 1.0f) * 0.8333333134651184f)) + 0.8799999952316284f);
+                      }
+                      _1952 = (_1884 - (_1894 * _1914));
+                      _1953 = (_1884 - (_1894 * _1929));
+                      _1954 = (_1884 - (_1894 * _1944));
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } else {
+                _1952 = _1876;
+                _1953 = _1879;
+                _1954 = _1882;
+              }
+            }
+            _1970 = ((mad(0.16386906802654266f, _1954, mad(0.14067870378494263f, _1953, (_1952 * 0.6954522132873535f))) - _1867) * cb0_012w) + _1867;
+            _1971 = ((mad(0.0955343171954155f, _1954, mad(0.8596711158752441f, _1953, (_1952 * 0.044794563204050064f))) - _1870) * cb0_012w) + _1870;
+            _1972 = ((mad(1.0015007257461548f, _1954, mad(0.004025210160762072f, _1953, (_1952 * -0.005525882821530104f))) - _1873) * cb0_012w) + _1873;
+            _1976 = max(max(_1970, _1971), _1972);
+            _1981 = (max(_1976, 1.000000013351432e-10f) - max(min(min(_1970, _1971), _1972), 1.000000013351432e-10f)) / max(_1976, 0.009999999776482582f);
+            _1994 = ((_1971 + _1970) + _1972) + (sqrt((((_1972 - _1971) * _1972) + ((_1971 - _1970) * _1971)) + ((_1970 - _1972) * _1970)) * 1.75f);
+            _1995 = _1994 * 0.3333333432674408f;
+            _1996 = _1981 + -0.4000000059604645f;
+            _1997 = _1996 * 5.0f;
+            _2001 = max((1.0f - abs(_1996 * 2.5f)), 0.0f);
+            _2012 = ((float((int)(((int)(uint)((int)(_1997 > 0.0f))) - ((int)(uint)((int)(_1997 < 0.0f))))) * (1.0f - (_2001 * _2001))) + 1.0f) * 0.02500000037252903f;
+            do {
+              _2021 = _2012;
+              if (!(_1995 <= 0.0533333346247673f)) {
+                if (!(_1995 >= 0.1599999964237213f)) {
+                  _2021 = (((0.23999999463558197f / _1994) + -0.5f) * _2012);
+                } else {
+                  _2021 = 0.0f;
+                }
+              }
+              _2022 = _2021 + 1.0f;
+              _2023 = _2022 * _1970;
+              _2024 = _2022 * _1971;
+              _2025 = _2022 * _1972;
+              do {
+                _2054 = 0.0f;
+                if (!((_2023 == _2024) && (_2024 == _2025))) {
+                  _2032 = ((_2023 * 2.0f) - _2024) - _2025;
+                  _2035 = ((_1971 - _1972) * 1.7320507764816284f) * _2022;
+                  _2037 = atan(_2035 / _2032);
+                  _2040 = (_2032 < 0.0f);
+                  _2041 = (_2032 == 0.0f);
+                  _2042 = (_2035 >= 0.0f);
+                  _2043 = (_2035 < 0.0f);
+                  _2054 = select((_2042 && _2041), 90.0f, select((_2043 && _2041), -90.0f, (select((_2043 && _2040), (_2037 + -3.1415927410125732f), select((_2042 && _2040), (_2037 + 3.1415927410125732f), _2037)) * 57.2957763671875f)));
+                }
+                _2059 = min(max(select((_2054 < 0.0f), (_2054 + 360.0f), _2054), 0.0f), 360.0f);
+                do {
+                  if (_2059 < -180.0f) {
+                    _2068 = (_2059 + 360.0f);
+                  } else {
+                    if (_2059 > 180.0f) {
+                      _2068 = (_2059 + -360.0f);
+                    } else {
+                      _2068 = _2059;
+                    }
+                  }
+                  do {
+                    _2107 = 0.0f;
+                    if ((_2068 > -67.5f) && (_2068 < 67.5f)) {
+                      _2074 = (_2068 + 67.5f) * 0.029629629105329514f;
+                      _2075 = int(_2074);
+                      _2077 = _2074 - float((int)(_2075));
+                      _2078 = _2077 * _2077;
+                      _2079 = _2078 * _2077;
+                      if (_2075 == 3) {
+                        _2107 = (((0.1666666716337204f - (_2077 * 0.5f)) + (_2078 * 0.5f)) - (_2079 * 0.1666666716337204f));
+                      } else {
+                        if (_2075 == 2) {
+                          _2107 = ((0.6666666865348816f - _2078) + (_2079 * 0.5f));
+                        } else {
+                          if (_2075 == 1) {
+                            _2107 = (((_2079 * -0.5f) + 0.1666666716337204f) + ((_2078 + _2077) * 0.5f));
+                          } else {
+                            _2107 = select((_2075 == 0), (_2079 * 0.1666666716337204f), 0.0f);
+                          }
+                        }
+                      }
+                    }
+                    _2116 = min(max(((((_1981 * 0.27000001072883606f) * (0.029999999329447746f - _2023)) * _2107) + _2023), 0.0f), 65535.0f);
+                    _2117 = min(max(_2024, 0.0f), 65535.0f);
+                    _2118 = min(max(_2025, 0.0f), 65535.0f);
+                    _2131 = min(max(mad(-0.21492856740951538f, _2118, mad(-0.2365107536315918f, _2117, (_2116 * 1.4514392614364624f))), 0.0f), 65504.0f);
+                    _2132 = min(max(mad(-0.09967592358589172f, _2118, mad(1.17622971534729f, _2117, (_2116 * -0.07655377686023712f))), 0.0f), 65504.0f);
+                    _2133 = min(max(mad(0.9977163076400757f, _2118, mad(-0.006032449658960104f, _2117, (_2116 * 0.008316148072481155f))), 0.0f), 65504.0f);
+                    _2134 = dot(float3(_2131, _2132, _2133), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+                    _15[0] = cb0_010x;
+                    _15[1] = cb0_010y;
+                    _15[2] = cb0_010z;
+                    _15[3] = cb0_010w;
+                    _15[4] = cb0_012x;
+                    _15[5] = cb0_012x;
+                    _16[0] = cb0_011x;
+                    _16[1] = cb0_011y;
+                    _16[2] = cb0_011z;
+                    _16[3] = cb0_011w;
+                    _16[4] = cb0_012y;
+                    _16[5] = cb0_012y;
+                    _2157 = log2(max((lerp(_2134, _2131, 0.9599999785423279f)), 1.000000013351432e-10f));
+                    _2158 = _2157 * 0.3010300099849701f;
+                    _2159 = log2(cb0_008x);
+                    _2160 = _2159 * 0.3010300099849701f;
+                    do {
+                      if (!(!(_2158 <= _2160))) {
+                        _2229 = (log2(cb0_008y) * 0.3010300099849701f);
+                      } else {
+                        _2167 = log2(cb0_009x);
+                        _2168 = _2167 * 0.3010300099849701f;
+                        if ((_2158 > _2160) && (_2158 < _2168)) {
+                          _2176 = ((_2157 - _2159) * 0.9030900001525879f) / ((_2167 - _2159) * 0.3010300099849701f);
+                          _2177 = int(_2176);
+                          _2179 = _2176 - float((int)(_2177));
+                          _2181 = _15[min((uint)(_2177), 5u)];
+                          _2184 = _15[min((uint)((_2177 + 1)), 5u)];
+                          _2189 = _2181 * 0.5f;
+                          _2229 = dot(float3((_2179 * _2179), _2179, 1.0f), float3(mad((_15[min((uint)((_2177 + 2)), 5u)]), 0.5f, mad(_2184, -1.0f, _2189)), (_2184 - _2181), mad(_2184, 0.5f, _2189)));
+                        } else {
+                          if (!(!(_2158 >= _2168))) {
+                            _2198 = log2(cb0_008z);
+                            if (_2158 < (_2198 * 0.3010300099849701f)) {
+                              _2206 = ((_2157 - _2167) * 0.9030900001525879f) / ((_2198 - _2167) * 0.3010300099849701f);
+                              _2207 = int(_2206);
+                              _2209 = _2206 - float((int)(_2207));
+                              _2211 = _16[min((uint)(_2207), 5u)];
+                              _2214 = _16[min((uint)((_2207 + 1)), 5u)];
+                              _2219 = _2211 * 0.5f;
+                              _2229 = dot(float3((_2209 * _2209), _2209, 1.0f), float3(mad((_16[min((uint)((_2207 + 2)), 5u)]), 0.5f, mad(_2214, -1.0f, _2219)), (_2214 - _2211), mad(_2214, 0.5f, _2219)));
+                            } else {
+                              _2229 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          } else {
+                            _2229 = (log2(cb0_008w) * 0.3010300099849701f);
+                          }
+                        }
+                      }
+                      _11[0] = cb0_010x;
+                      _11[1] = cb0_010y;
+                      _11[2] = cb0_010z;
+                      _11[3] = cb0_010w;
+                      _11[4] = cb0_012x;
+                      _11[5] = cb0_012x;
+                      _12[0] = cb0_011x;
+                      _12[1] = cb0_011y;
+                      _12[2] = cb0_011z;
+                      _12[3] = cb0_011w;
+                      _12[4] = cb0_012y;
+                      _12[5] = cb0_012y;
+                      _2245 = log2(max((lerp(_2134, _2132, 0.9599999785423279f)), 1.000000013351432e-10f));
+                      _2246 = _2245 * 0.3010300099849701f;
+                      do {
+                        if (!(!(_2246 <= _2160))) {
+                          _2315 = (log2(cb0_008y) * 0.3010300099849701f);
+                        } else {
+                          _2253 = log2(cb0_009x);
+                          _2254 = _2253 * 0.3010300099849701f;
+                          if ((_2246 > _2160) && (_2246 < _2254)) {
+                            _2262 = ((_2245 - _2159) * 0.9030900001525879f) / ((_2253 - _2159) * 0.3010300099849701f);
+                            _2263 = int(_2262);
+                            _2265 = _2262 - float((int)(_2263));
+                            _2267 = _11[min((uint)(_2263), 5u)];
+                            _2270 = _11[min((uint)((_2263 + 1)), 5u)];
+                            _2275 = _2267 * 0.5f;
+                            _2315 = dot(float3((_2265 * _2265), _2265, 1.0f), float3(mad((_11[min((uint)((_2263 + 2)), 5u)]), 0.5f, mad(_2270, -1.0f, _2275)), (_2270 - _2267), mad(_2270, 0.5f, _2275)));
+                          } else {
+                            if (!(!(_2246 >= _2254))) {
+                              _2284 = log2(cb0_008z);
+                              if (_2246 < (_2284 * 0.3010300099849701f)) {
+                                _2292 = ((_2245 - _2253) * 0.9030900001525879f) / ((_2284 - _2253) * 0.3010300099849701f);
+                                _2293 = int(_2292);
+                                _2295 = _2292 - float((int)(_2293));
+                                _2297 = _12[min((uint)(_2293), 5u)];
+                                _2300 = _12[min((uint)((_2293 + 1)), 5u)];
+                                _2305 = _2297 * 0.5f;
+                                _2315 = dot(float3((_2295 * _2295), _2295, 1.0f), float3(mad((_12[min((uint)((_2293 + 2)), 5u)]), 0.5f, mad(_2300, -1.0f, _2305)), (_2300 - _2297), mad(_2300, 0.5f, _2305)));
+                              } else {
+                                _2315 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            } else {
+                              _2315 = (log2(cb0_008w) * 0.3010300099849701f);
+                            }
+                          }
+                        }
+                        _13[0] = cb0_010x;
+                        _13[1] = cb0_010y;
+                        _13[2] = cb0_010z;
+                        _13[3] = cb0_010w;
+                        _13[4] = cb0_012x;
+                        _13[5] = cb0_012x;
+                        _14[0] = cb0_011x;
+                        _14[1] = cb0_011y;
+                        _14[2] = cb0_011z;
+                        _14[3] = cb0_011w;
+                        _14[4] = cb0_012y;
+                        _14[5] = cb0_012y;
+                        _2331 = log2(max((lerp(_2134, _2133, 0.9599999785423279f)), 1.000000013351432e-10f));
+                        _2332 = _2331 * 0.3010300099849701f;
+                        do {
+                          if (!(!(_2332 <= _2160))) {
+                            _2401 = (log2(cb0_008y) * 0.3010300099849701f);
+                          } else {
+                            _2339 = log2(cb0_009x);
+                            _2340 = _2339 * 0.3010300099849701f;
+                            if ((_2332 > _2160) && (_2332 < _2340)) {
+                              _2348 = ((_2331 - _2159) * 0.9030900001525879f) / ((_2339 - _2159) * 0.3010300099849701f);
+                              _2349 = int(_2348);
+                              _2351 = _2348 - float((int)(_2349));
+                              _2353 = _13[min((uint)(_2349), 5u)];
+                              _2356 = _13[min((uint)((_2349 + 1)), 5u)];
+                              _2361 = _2353 * 0.5f;
+                              _2401 = dot(float3((_2351 * _2351), _2351, 1.0f), float3(mad((_13[min((uint)((_2349 + 2)), 5u)]), 0.5f, mad(_2356, -1.0f, _2361)), (_2356 - _2353), mad(_2356, 0.5f, _2361)));
+                            } else {
+                              if (!(!(_2332 >= _2340))) {
+                                _2370 = log2(cb0_008z);
+                                if (_2332 < (_2370 * 0.3010300099849701f)) {
+                                  _2378 = ((_2331 - _2339) * 0.9030900001525879f) / ((_2370 - _2339) * 0.3010300099849701f);
+                                  _2379 = int(_2378);
+                                  _2381 = _2378 - float((int)(_2379));
+                                  _2383 = _14[min((uint)(_2379), 5u)];
+                                  _2386 = _14[min((uint)((_2379 + 1)), 5u)];
+                                  _2391 = _2383 * 0.5f;
+                                  _2401 = dot(float3((_2381 * _2381), _2381, 1.0f), float3(mad((_14[min((uint)((_2379 + 2)), 5u)]), 0.5f, mad(_2386, -1.0f, _2391)), (_2386 - _2383), mad(_2386, 0.5f, _2391)));
+                                } else {
+                                  _2401 = (log2(cb0_008w) * 0.3010300099849701f);
+                                }
+                              } else {
+                                _2401 = (log2(cb0_008w) * 0.3010300099849701f);
+                              }
+                            }
+                          }
+                          _2405 = cb0_008w - cb0_008y;
+                          _2406 = (exp2(_2229 * 3.321928024291992f) - cb0_008y) / _2405;
+                          _2408 = (exp2(_2315 * 3.321928024291992f) - cb0_008y) / _2405;
+                          _2410 = (exp2(_2401 * 3.321928024291992f) - cb0_008y) / _2405;
+                          _2413 = mad(0.15618768334388733f, _2410, mad(0.13400420546531677f, _2408, (_2406 * 0.6624541878700256f)));
+                          _2416 = mad(0.053689517080783844f, _2410, mad(0.6740817427635193f, _2408, (_2406 * 0.2722287178039551f)));
+                          _2419 = mad(1.0103391408920288f, _2410, mad(0.00406073359772563f, _2408, (_2406 * -0.005574649665504694f)));
+                          _2432 = min(max(mad(-0.23642469942569733f, _2419, mad(-0.32480329275131226f, _2416, (_2413 * 1.6410233974456787f))), 0.0f), 1.0f);
+                          _2433 = min(max(mad(0.016756348311901093f, _2419, mad(1.6153316497802734f, _2416, (_2413 * -0.663662850856781f))), 0.0f), 1.0f);
+                          _2434 = min(max(mad(0.9883948564529419f, _2419, mad(-0.008284442126750946f, _2416, (_2413 * 0.011721894145011902f))), 0.0f), 1.0f);
+                          _2437 = mad(0.15618768334388733f, _2434, mad(0.13400420546531677f, _2433, (_2432 * 0.6624541878700256f)));
+                          _2440 = mad(0.053689517080783844f, _2434, mad(0.6740817427635193f, _2433, (_2432 * 0.2722287178039551f)));
+                          _2443 = mad(1.0103391408920288f, _2434, mad(0.00406073359772563f, _2433, (_2432 * -0.005574649665504694f)));
+                          _2465 = min(max((min(max(mad(-0.23642469942569733f, _2443, mad(-0.32480329275131226f, _2440, (_2437 * 1.6410233974456787f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          _2466 = min(max((min(max(mad(0.016756348311901093f, _2443, mad(1.6153316497802734f, _2440, (_2437 * -0.663662850856781f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          _2467 = min(max((min(max(mad(0.9883948564529419f, _2443, mad(-0.008284442126750946f, _2440, (_2437 * 0.011721894145011902f))), 0.0f), 65535.0f) * cb0_008w), 0.0f), 65535.0f);
+                          do {
+                            _2480 = _2465;
+                            _2481 = _2466;
+                            _2482 = _2467;
+                            if (!(cb0_040w == 6)) {
+                              _2480 = mad(_63, _2467, mad(_62, _2466, (_2465 * _61)));
+                              _2481 = mad(_66, _2467, mad(_65, _2466, (_2465 * _64)));
+                              _2482 = mad(_69, _2467, mad(_68, _2466, (_2465 * _67)));
+                            }
+                            _2492 = exp2(log2(_2480 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2493 = exp2(log2(_2481 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2494 = exp2(log2(_2482 * 9.999999747378752e-05f) * 0.1593017578125f);
+                            _2659 = exp2(log2((1.0f / ((_2492 * 18.6875f) + 1.0f)) * ((_2492 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                            _2660 = exp2(log2((1.0f / ((_2493 * 18.6875f) + 1.0f)) * ((_2493 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                            _2661 = exp2(log2((1.0f / ((_2494 * 18.6875f) + 1.0f)) * ((_2494 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+                          } while (false);
+                        } while (false);
+                      } while (false);
+                    } while (false);
+                  } while (false);
+                } while (false);
+              } while (false);
+            } while (false);
+          } while (false);
+        } else {
+          if (cb0_040w == 7) {
+            _2539 = mad((WorkingColorSpace_128[0].z), _977, mad((WorkingColorSpace_128[0].y), _976, ((WorkingColorSpace_128[0].x) * _975)));
+            _2542 = mad((WorkingColorSpace_128[1].z), _977, mad((WorkingColorSpace_128[1].y), _976, ((WorkingColorSpace_128[1].x) * _975)));
+            _2545 = mad((WorkingColorSpace_128[2].z), _977, mad((WorkingColorSpace_128[2].y), _976, ((WorkingColorSpace_128[2].x) * _975)));
+            _2564 = exp2(log2(mad(_63, _2545, mad(_62, _2542, (_2539 * _61))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2565 = exp2(log2(mad(_66, _2545, mad(_65, _2542, (_2539 * _64))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2566 = exp2(log2(mad(_69, _2545, mad(_68, _2542, (_2539 * _67))) * 9.999999747378752e-05f) * 0.1593017578125f);
+            _2659 = exp2(log2((1.0f / ((_2564 * 18.6875f) + 1.0f)) * ((_2564 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+            _2660 = exp2(log2((1.0f / ((_2565 * 18.6875f) + 1.0f)) * ((_2565 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+            _2661 = exp2(log2((1.0f / ((_2566 * 18.6875f) + 1.0f)) * ((_2566 * 18.8515625f) + 0.8359375f)) * 78.84375f);
+          } else {
+            if (!(cb0_040w == 8)) {
+              if (cb0_040w == 9) {
+                _2613 = mad((WorkingColorSpace_128[0].z), _965, mad((WorkingColorSpace_128[0].y), _964, ((WorkingColorSpace_128[0].x) * _963)));
+                _2616 = mad((WorkingColorSpace_128[1].z), _965, mad((WorkingColorSpace_128[1].y), _964, ((WorkingColorSpace_128[1].x) * _963)));
+                _2619 = mad((WorkingColorSpace_128[2].z), _965, mad((WorkingColorSpace_128[2].y), _964, ((WorkingColorSpace_128[2].x) * _963)));
+                _2659 = mad(_63, _2619, mad(_62, _2616, (_2613 * _61)));
+                _2660 = mad(_66, _2619, mad(_65, _2616, (_2613 * _64)));
+                _2661 = mad(_69, _2619, mad(_68, _2616, (_2613 * _67)));
+              } else {
+                _2632 = mad((WorkingColorSpace_128[0].z), _991, mad((WorkingColorSpace_128[0].y), _990, ((WorkingColorSpace_128[0].x) * _989)));
+                _2635 = mad((WorkingColorSpace_128[1].z), _991, mad((WorkingColorSpace_128[1].y), _990, ((WorkingColorSpace_128[1].x) * _989)));
+                _2638 = mad((WorkingColorSpace_128[2].z), _991, mad((WorkingColorSpace_128[2].y), _990, ((WorkingColorSpace_128[2].x) * _989)));
+                _2659 = exp2(log2(mad(_63, _2638, mad(_62, _2635, (_2632 * _61)))) * cb0_040z);
+                _2660 = exp2(log2(mad(_66, _2638, mad(_65, _2635, (_2632 * _64)))) * cb0_040z);
+                _2661 = exp2(log2(mad(_69, _2638, mad(_68, _2635, (_2632 * _67)))) * cb0_040z);
+              }
+            } else {
+              _2659 = _975;
+              _2660 = _976;
+              _2661 = _977;
+            }
+          }
+        }
+      }
+    }
+  }
+  u0[int3((int)(SV_DispatchThreadID.x), (int)(SV_DispatchThreadID.y), (int)(SV_DispatchThreadID.z))] = float4((_2659 * 0.9523810148239136f), (_2660 * 0.9523810148239136f), (_2661 * 0.9523810148239136f), 0.0f);
+}

--- a/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xD4F61CC8.cs_6_6.hlsl
+++ b/src/games/ue-extended/lutbuilder/sm6/lutbuilder_0xD4F61CC8.cs_6_6.hlsl
@@ -1,0 +1,530 @@
+// From Halo Campaign Evolved
+
+#include "../lutbuilderoutput.hlsli"
+
+RWTexture3D<float4> u0 : register(u0);
+
+cbuffer cb0 : register(b0) {
+  float cb0_013x : packoffset(c013.x);
+  float cb0_013y : packoffset(c013.y);
+  float cb0_013z : packoffset(c013.z);
+  float cb0_013w : packoffset(c013.w);
+  float cb0_014x : packoffset(c014.x);
+  float cb0_014y : packoffset(c014.y);
+  float cb0_014z : packoffset(c014.z);
+  float cb0_015x : packoffset(c015.x);
+  float cb0_015y : packoffset(c015.y);
+  float cb0_015z : packoffset(c015.z);
+  float cb0_015w : packoffset(c015.w);
+  float cb0_016x : packoffset(c016.x);
+  float cb0_016y : packoffset(c016.y);
+  float cb0_016z : packoffset(c016.z);
+  float cb0_016w : packoffset(c016.w);
+  float cb0_017x : packoffset(c017.x);
+  float cb0_017y : packoffset(c017.y);
+  float cb0_017z : packoffset(c017.z);
+  float cb0_017w : packoffset(c017.w);
+  float cb0_018x : packoffset(c018.x);
+  float cb0_018y : packoffset(c018.y);
+  float cb0_018z : packoffset(c018.z);
+  float cb0_018w : packoffset(c018.w);
+  float cb0_019x : packoffset(c019.x);
+  float cb0_019y : packoffset(c019.y);
+  float cb0_019z : packoffset(c019.z);
+  float cb0_019w : packoffset(c019.w);
+  float cb0_020x : packoffset(c020.x);
+  float cb0_020y : packoffset(c020.y);
+  float cb0_020z : packoffset(c020.z);
+  float cb0_020w : packoffset(c020.w);
+  float cb0_021x : packoffset(c021.x);
+  float cb0_021y : packoffset(c021.y);
+  float cb0_021z : packoffset(c021.z);
+  float cb0_021w : packoffset(c021.w);
+  float cb0_022x : packoffset(c022.x);
+  float cb0_022y : packoffset(c022.y);
+  float cb0_022z : packoffset(c022.z);
+  float cb0_022w : packoffset(c022.w);
+  float cb0_023x : packoffset(c023.x);
+  float cb0_023y : packoffset(c023.y);
+  float cb0_023z : packoffset(c023.z);
+  float cb0_023w : packoffset(c023.w);
+  float cb0_024x : packoffset(c024.x);
+  float cb0_024y : packoffset(c024.y);
+  float cb0_024z : packoffset(c024.z);
+  float cb0_024w : packoffset(c024.w);
+  float cb0_025x : packoffset(c025.x);
+  float cb0_025y : packoffset(c025.y);
+  float cb0_025z : packoffset(c025.z);
+  float cb0_025w : packoffset(c025.w);
+  float cb0_026x : packoffset(c026.x);
+  float cb0_026y : packoffset(c026.y);
+  float cb0_026z : packoffset(c026.z);
+  float cb0_026w : packoffset(c026.w);
+  float cb0_027x : packoffset(c027.x);
+  float cb0_027y : packoffset(c027.y);
+  float cb0_027z : packoffset(c027.z);
+  float cb0_027w : packoffset(c027.w);
+  float cb0_028x : packoffset(c028.x);
+  float cb0_028y : packoffset(c028.y);
+  float cb0_028z : packoffset(c028.z);
+  float cb0_028w : packoffset(c028.w);
+  float cb0_029x : packoffset(c029.x);
+  float cb0_029y : packoffset(c029.y);
+  float cb0_029z : packoffset(c029.z);
+  float cb0_029w : packoffset(c029.w);
+  float cb0_030x : packoffset(c030.x);
+  float cb0_030y : packoffset(c030.y);
+  float cb0_030z : packoffset(c030.z);
+  float cb0_030w : packoffset(c030.w);
+  float cb0_031x : packoffset(c031.x);
+  float cb0_031y : packoffset(c031.y);
+  float cb0_031z : packoffset(c031.z);
+  float cb0_031w : packoffset(c031.w);
+  float cb0_032x : packoffset(c032.x);
+  float cb0_032y : packoffset(c032.y);
+  float cb0_032z : packoffset(c032.z);
+  float cb0_032w : packoffset(c032.w);
+  float cb0_033x : packoffset(c033.x);
+  float cb0_033y : packoffset(c033.y);
+  float cb0_033z : packoffset(c033.z);
+  float cb0_033w : packoffset(c033.w);
+  float cb0_034x : packoffset(c034.x);
+  float cb0_034y : packoffset(c034.y);
+  float cb0_034z : packoffset(c034.z);
+  float cb0_034w : packoffset(c034.w);
+  float cb0_035x : packoffset(c035.x);
+  float cb0_035w : packoffset(c035.w);
+  float cb0_036x : packoffset(c036.x);
+  float cb0_036y : packoffset(c036.y);
+  float cb0_036z : packoffset(c036.z);
+  float cb0_036w : packoffset(c036.w);
+  float cb0_037x : packoffset(c037.x);
+  float cb0_037y : packoffset(c037.y);
+  float cb0_037z : packoffset(c037.z);
+  float cb0_037w : packoffset(c037.w);
+  float cb0_038x : packoffset(c038.x);
+  float cb0_038y : packoffset(c038.y);
+  float cb0_039x : packoffset(c039.x);
+  float cb0_039y : packoffset(c039.y);
+  float cb0_039z : packoffset(c039.z);
+  float cb0_040y : packoffset(c040.y);
+  int cb0_041x : packoffset(c041.x);
+  float cb0_042x : packoffset(c042.x);
+  float cb0_042y : packoffset(c042.y);
+};
+
+cbuffer cb1 : register(b1) {
+  float4 WorkingColorSpace_000[4] : packoffset(c000.x);
+  float4 WorkingColorSpace_064[4] : packoffset(c004.x);
+  float4 WorkingColorSpace_128[4] : packoffset(c008.x);
+  float4 WorkingColorSpace_192[4] : packoffset(c012.x);
+  float4 WorkingColorSpace_256[4] : packoffset(c016.x);
+  int WorkingColorSpace_320 : packoffset(c020.x);
+};
+
+// DXIL FirstbitHi: returns bit position counting from MSB (leading zeros count)
+uint firstbithigh_msb(int value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+uint firstbithigh_msb(uint value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }
+
+[numthreads(8, 8, 8)]
+void main(
+  uint3 SV_DispatchThreadID : SV_DispatchThreadID,
+  uint3 SV_GroupID : SV_GroupID,
+  uint3 SV_GroupThreadID : SV_GroupThreadID,
+  uint SV_GroupIndex : SV_GroupIndex
+) {
+  float _20;
+  float _25;
+  float _49;
+  float _50;
+  float _51;
+  float _52;
+  float _53;
+  float _54;
+  float _55;
+  float _56;
+  float _57;
+  float _574;
+  float _607;
+  float _621;
+  float _685;
+  float _937;
+  float _938;
+  float _939;
+  float _950;
+  float _961;
+  float _972;
+  bool _38;
+  float _70;
+  float _71;
+  float _72;
+  float _87;
+  float _90;
+  float _93;
+  float _94;
+  float _98;
+  float _99;
+  float _100;
+  float _112;
+  float _128;
+  float _129;
+  float _130;
+  float _131;
+  float _145;
+  float _159;
+  float _173;
+  float _187;
+  float _201;
+  float _205;
+  float _206;
+  float _207;
+  float _264;
+  float _268;
+  float _269;
+  float _278;
+  float _287;
+  float _296;
+  float _305;
+  float _314;
+  float _377;
+  float _381;
+  float _390;
+  float _399;
+  float _408;
+  float _417;
+  float _426;
+  float _484;
+  float _495;
+  float _497;
+  float _499;
+  float _514;
+  float _515;
+  float _516;
+  float _519;
+  float _522;
+  float _525;
+  float _529;
+  float _534;
+  float _547;
+  float _548;
+  float _549;
+  float _550;
+  float _554;
+  float _565;
+  float _575;
+  float _576;
+  float _577;
+  float _578;
+  float _585;
+  float _588;
+  float _590;
+  bool _593;
+  bool _594;
+  bool _595;
+  bool _596;
+  float _612;
+  float _625;
+  float _629;
+  float _635;
+  float _645;
+  float _646;
+  float _647;
+  float _648;
+  float _663;
+  float _665;
+  float _667;
+  float _676;
+  float _688;
+  float _690;
+  float _694;
+  float _695;
+  float _696;
+  float _700;
+  float _701;
+  float _702;
+  float _703;
+  float _705;
+  float _706;
+  float _707;
+  float _708;
+  float _727;
+  float _729;
+  float _754;
+  float _755;
+  float _756;
+  float _763;
+  float _767;
+  float _768;
+  float _769;
+  bool _770;
+  float _774;
+  float _775;
+  float _776;
+  float _795;
+  float _796;
+  float _797;
+  float _798;
+  float _818;
+  float _819;
+  float _820;
+  float _836;
+  float _837;
+  float _838;
+  float _860;
+  float _861;
+  float _862;
+  float _888;
+  float _889;
+  float _890;
+  float _911;
+  float _912;
+  float _913;
+  float _920;
+  float _923;
+  float _926;
+  _20 = 0.5f / cb0_035x;
+  _25 = cb0_035x + -1.0f;
+  if (!(cb0_041x == 1)) {
+    if (!(cb0_041x == 2)) {
+      if (!(cb0_041x == 3)) {
+        _38 = (cb0_041x == 4);
+        _49 = select(_38, 1.0f, 1.705051064491272f);
+        _50 = select(_38, 0.0f, -0.6217921376228333f);
+        _51 = select(_38, 0.0f, -0.0832589864730835f);
+        _52 = select(_38, 0.0f, -0.13025647401809692f);
+        _53 = select(_38, 1.0f, 1.140804648399353f);
+        _54 = select(_38, 0.0f, -0.010548308491706848f);
+        _55 = select(_38, 0.0f, -0.024003351107239723f);
+        _56 = select(_38, 0.0f, -0.1289689838886261f);
+        _57 = select(_38, 1.0f, 1.1529725790023804f);
+      } else {
+        _49 = 0.6954522132873535f;
+        _50 = 0.14067870378494263f;
+        _51 = 0.16386906802654266f;
+        _52 = 0.044794563204050064f;
+        _53 = 0.8596711158752441f;
+        _54 = 0.0955343171954155f;
+        _55 = -0.005525882821530104f;
+        _56 = 0.004025210160762072f;
+        _57 = 1.0015007257461548f;
+      }
+    } else {
+      _49 = 1.0258246660232544f;
+      _50 = -0.020053181797266006f;
+      _51 = -0.005771636962890625f;
+      _52 = -0.002234415616840124f;
+      _53 = 1.0045864582061768f;
+      _54 = -0.002352118492126465f;
+      _55 = -0.005013350863009691f;
+      _56 = -0.025290070101618767f;
+      _57 = 1.0303035974502563f;
+    }
+  } else {
+    _49 = 1.3792141675949097f;
+    _50 = -0.30886411666870117f;
+    _51 = -0.0703500509262085f;
+    _52 = -0.06933490186929703f;
+    _53 = 1.08229660987854f;
+    _54 = -0.012961871922016144f;
+    _55 = -0.0021590073592960835f;
+    _56 = -0.0454593189060688f;
+    _57 = 1.0476183891296387f;
+  }
+  _70 = (exp2((((cb0_035x * ((cb0_042x * (((float)((uint)SV_DispatchThreadID.x)) + 0.5f)) - _20)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _71 = (exp2((((cb0_035x * ((cb0_042y * (((float)((uint)SV_DispatchThreadID.y)) + 0.5f)) - _20)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _72 = (exp2(((((float)((uint)SV_DispatchThreadID.z)) / _25) + -0.4340175986289978f) * 14.0f) * 0.18000000715255737f) + -0.002667719265446067f;
+  _87 = mad((WorkingColorSpace_128[0].z), _72, mad((WorkingColorSpace_128[0].y), _71, ((WorkingColorSpace_128[0].x) * _70)));
+  _90 = mad((WorkingColorSpace_128[1].z), _72, mad((WorkingColorSpace_128[1].y), _71, ((WorkingColorSpace_128[1].x) * _70)));
+  _93 = mad((WorkingColorSpace_128[2].z), _72, mad((WorkingColorSpace_128[2].y), _71, ((WorkingColorSpace_128[2].x) * _70)));
+  _94 = dot(float3(_87, _90, _93), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _98 = (_87 / _94) + -1.0f;
+  _99 = (_90 / _94) + -1.0f;
+  _100 = (_93 / _94) + -1.0f;
+  // ExpandGamut set to 0
+  _112 = (1.0f - exp2(((_94 * _94) * -4.0f) * 0.f)) * (1.0f - exp2(dot(float3(_98, _99, _100), float3(_98, _99, _100)) * -4.0f));
+  _128 = ((mad(-0.06368321925401688f, _93, mad(-0.3292922377586365f, _90, (_87 * 1.3704125881195068f))) - _87) * _112) + _87;
+  _129 = ((mad(-0.010861365124583244f, _93, mad(1.0970927476882935f, _90, (_87 * -0.08343357592821121f))) - _90) * _112) + _90;
+  _130 = ((mad(1.2036951780319214f, _93, mad(-0.09862580895423889f, _90, (_87 * -0.02579331398010254f))) - _93) * _112) + _93;
+  _131 = dot(float3(_128, _129, _130), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _145 = cb0_019w + cb0_024w;
+  _159 = cb0_018w * cb0_023w;
+  _173 = cb0_017w * cb0_022w;
+  _187 = cb0_016w * cb0_021w;
+  _201 = cb0_015w * cb0_020w;
+  _205 = _128 - _131;
+  _206 = _129 - _131;
+  _207 = _130 - _131;
+  _264 = saturate(_131 / cb0_035w);
+  _268 = (_264 * _264) * (3.0f - (_264 * 2.0f));
+  _269 = 1.0f - _268;
+  _278 = cb0_019w + cb0_034w;
+  _287 = cb0_018w * cb0_033w;
+  _296 = cb0_017w * cb0_032w;
+  _305 = cb0_016w * cb0_031w;
+  _314 = cb0_015w * cb0_030w;
+  _377 = saturate((_131 - cb0_036x) / (cb0_036y - cb0_036x));
+  _381 = (_377 * _377) * (3.0f - (_377 * 2.0f));
+  _390 = cb0_019w + cb0_029w;
+  _399 = cb0_018w * cb0_028w;
+  _408 = cb0_017w * cb0_027w;
+  _417 = cb0_016w * cb0_026w;
+  _426 = cb0_015w * cb0_025w;
+  _484 = _268 - _381;
+  _495 = ((_381 * (((cb0_019x + cb0_034x) + _278) + (((cb0_018x * cb0_033x) * _287) * exp2(log2(exp2(((cb0_016x * cb0_031x) * _305) * log2(max(0.0f, ((((cb0_015x * cb0_030x) * _314) * _205) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_032x) * _296)))))) + (_269 * (((cb0_019x + cb0_024x) + _145) + (((cb0_018x * cb0_023x) * _159) * exp2(log2(exp2(((cb0_016x * cb0_021x) * _187) * log2(max(0.0f, ((((cb0_015x * cb0_020x) * _201) * _205) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_022x) * _173))))))) + ((((cb0_019x + cb0_029x) + _390) + (((cb0_018x * cb0_028x) * _399) * exp2(log2(exp2(((cb0_016x * cb0_026x) * _417) * log2(max(0.0f, ((((cb0_015x * cb0_025x) * _426) * _205) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017x * cb0_027x) * _408))))) * _484);
+  _497 = ((_381 * (((cb0_019y + cb0_034y) + _278) + (((cb0_018y * cb0_033y) * _287) * exp2(log2(exp2(((cb0_016y * cb0_031y) * _305) * log2(max(0.0f, ((((cb0_015y * cb0_030y) * _314) * _206) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_032y) * _296)))))) + (_269 * (((cb0_019y + cb0_024y) + _145) + (((cb0_018y * cb0_023y) * _159) * exp2(log2(exp2(((cb0_016y * cb0_021y) * _187) * log2(max(0.0f, ((((cb0_015y * cb0_020y) * _201) * _206) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_022y) * _173))))))) + ((((cb0_019y + cb0_029y) + _390) + (((cb0_018y * cb0_028y) * _399) * exp2(log2(exp2(((cb0_016y * cb0_026y) * _417) * log2(max(0.0f, ((((cb0_015y * cb0_025y) * _426) * _206) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017y * cb0_027y) * _408))))) * _484);
+  _499 = ((_381 * (((cb0_019z + cb0_034z) + _278) + (((cb0_018z * cb0_033z) * _287) * exp2(log2(exp2(((cb0_016z * cb0_031z) * _305) * log2(max(0.0f, ((((cb0_015z * cb0_030z) * _314) * _207) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_032z) * _296)))))) + (_269 * (((cb0_019z + cb0_024z) + _145) + (((cb0_018z * cb0_023z) * _159) * exp2(log2(exp2(((cb0_016z * cb0_021z) * _187) * log2(max(0.0f, ((((cb0_015z * cb0_020z) * _201) * _207) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_022z) * _173))))))) + ((((cb0_019z + cb0_029z) + _390) + (((cb0_018z * cb0_028z) * _399) * exp2(log2(exp2(((cb0_016z * cb0_026z) * _417) * log2(max(0.0f, ((((cb0_015z * cb0_025z) * _426) * _207) + _131)) * 5.55555534362793f)) * 0.18000000715255737f) * (1.0f / ((cb0_017z * cb0_027z) * _408))))) * _484);
+  UECbufferConfig cb_config = CreateCbufferConfig();
+  cb_config.ue_filmblackclip = cb0_038x;
+  cb_config.ue_filmtoe = cb0_037z;
+  cb_config.ue_filmshoulder = cb0_037w;
+  cb_config.ue_filmslope = cb0_037y;
+  cb_config.ue_filmwhiteclip = cb0_038y;
+  cb_config.ue_tonecurveammount = cb0_037x;
+  cb_config.ue_mappingpolynomial = float3(cb0_039x, cb0_039y, cb0_039z);
+  cb_config.ue_overlaycolor = float4(cb0_013x, cb0_013y, cb0_013z, cb0_013w);
+  cb_config.ue_bluecorrection = cb0_036z;
+  cb_config.ue_colorscale = float3(cb0_014x, cb0_014y, cb0_014z);
+
+  float4 output = ProcessLutbuilder(float3(_495, _497, _499), cb_config, u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))], 3u);
+  u0[int3((uint)(SV_DispatchThreadID.x), (uint)(SV_DispatchThreadID.y), (uint)(SV_DispatchThreadID.z))] = output;
+  return;
+
+  _514 = ((mad(0.061360642313957214f, _499, mad(-4.540197551250458e-09f, _497, (_495 * 0.9386394023895264f))) - _495) * cb0_036z) + _495;
+  _515 = ((mad(0.169205904006958f, _499, mad(0.8307942152023315f, _497, (_495 * 6.775371730327606e-08f))) - _497) * cb0_036z) + _497;
+  _516 = (mad(-2.3283064365386963e-10f, _497, (_495 * -9.313225746154785e-10f)) * cb0_036z) + _499;
+  _519 = mad(0.16386905312538147f, _516, mad(0.14067868888378143f, _515, (_514 * 0.6954522132873535f)));
+  _522 = mad(0.0955343246459961f, _516, mad(0.8596711158752441f, _515, (_514 * 0.044794581830501556f)));
+  _525 = mad(1.0015007257461548f, _516, mad(0.004025210160762072f, _515, (_514 * -0.005525882821530104f)));
+  _529 = max(max(_519, _522), _525);
+  _534 = (max(_529, 1.000000013351432e-10f) - max(min(min(_519, _522), _525), 1.000000013351432e-10f)) / max(_529, 0.009999999776482582f);
+  _547 = ((_522 + _519) + _525) + (sqrt((((_525 - _522) * _525) + ((_522 - _519) * _522)) + ((_519 - _525) * _519)) * 1.75f);
+  _548 = _547 * 0.3333333432674408f;
+  _549 = _534 + -0.4000000059604645f;
+  _550 = _549 * 5.0f;
+  _554 = max((1.0f - abs(_549 * 2.5f)), 0.0f);
+  _565 = ((float((int)(((int)(uint)((int)(_550 > 0.0f))) - ((int)(uint)((int)(_550 < 0.0f))))) * (1.0f - (_554 * _554))) + 1.0f) * 0.02500000037252903f;
+  if (!(_548 <= 0.0533333346247673f)) {
+    if (!(_548 >= 0.1599999964237213f)) {
+      _574 = (((0.23999999463558197f / _547) + -0.5f) * _565);
+    } else {
+      _574 = 0.0f;
+    }
+  } else {
+    _574 = _565;
+  }
+  _575 = _574 + 1.0f;
+  _576 = _575 * _519;
+  _577 = _575 * _522;
+  _578 = _575 * _525;
+  if (!((_576 == _577) && (_577 == _578))) {
+    _585 = ((_576 * 2.0f) - _577) - _578;
+    _588 = ((_522 - _525) * 1.7320507764816284f) * _575;
+    _590 = atan(_588 / _585);
+    _593 = (_585 < 0.0f);
+    _594 = (_585 == 0.0f);
+    _595 = (_588 >= 0.0f);
+    _596 = (_588 < 0.0f);
+    _607 = select((_595 && _594), 90.0f, select((_596 && _594), -90.0f, (select((_596 && _593), (_590 + -3.1415927410125732f), select((_595 && _593), (_590 + 3.1415927410125732f), _590)) * 57.2957763671875f)));
+  } else {
+    _607 = 0.0f;
+  }
+  _612 = min(max(select((_607 < 0.0f), (_607 + 360.0f), _607), 0.0f), 360.0f);
+  if (_612 < -180.0f) {
+    _621 = (_612 + 360.0f);
+  } else {
+    if (_612 > 180.0f) {
+      _621 = (_612 + -360.0f);
+    } else {
+      _621 = _612;
+    }
+  }
+  _625 = saturate(1.0f - abs(_621 * 0.014814814552664757f));
+  _629 = (_625 * _625) * (3.0f - (_625 * 2.0f));
+  _635 = ((_629 * _629) * ((_534 * 0.18000000715255737f) * (0.029999999329447746f - _576))) + _576;
+  _645 = max(0.0f, mad(-0.21492856740951538f, _578, mad(-0.2365107536315918f, _577, (_635 * 1.4514392614364624f))));
+  _646 = max(0.0f, mad(-0.09967592358589172f, _578, mad(1.17622971534729f, _577, (_635 * -0.07655377686023712f))));
+  _647 = max(0.0f, mad(0.9977163076400757f, _578, mad(-0.006032449658960104f, _577, (_635 * 0.008316148072481155f))));
+  _648 = dot(float3(_645, _646, _647), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _663 = (cb0_038x + 1.0f) - cb0_037z;
+  _665 = cb0_038y + 1.0f;
+  _667 = _665 - cb0_037w;
+  if (cb0_037z > 0.800000011920929f) {
+    _685 = (((0.8199999928474426f - cb0_037z) / cb0_037y) + -0.7447274923324585f);
+  } else {
+    _676 = (cb0_038x + 0.18000000715255737f) / _663;
+    _685 = (-0.7447274923324585f - ((log2(_676 / (2.0f - _676)) * 0.3465735912322998f) * (_663 / cb0_037y)));
+  }
+  _688 = ((1.0f - cb0_037z) / cb0_037y) - _685;
+  _690 = (cb0_037w / cb0_037y) - _688;
+  _694 = log2(lerp(_648, _645, 0.9599999785423279f)) * 0.3010300099849701f;
+  _695 = log2(lerp(_648, _646, 0.9599999785423279f)) * 0.3010300099849701f;
+  _696 = log2(lerp(_648, _647, 0.9599999785423279f)) * 0.3010300099849701f;
+  _700 = cb0_037y * (_694 + _688);
+  _701 = cb0_037y * (_695 + _688);
+  _702 = cb0_037y * (_696 + _688);
+  _703 = _663 * 2.0f;
+  _705 = (cb0_037y * -2.0f) / _663;
+  _706 = _694 - _685;
+  _707 = _695 - _685;
+  _708 = _696 - _685;
+  _727 = _667 * 2.0f;
+  _729 = (cb0_037y * 2.0f) / _667;
+  _754 = select((_694 < _685), ((_703 / (exp2((_706 * 1.4426950216293335f) * _705) + 1.0f)) - cb0_038x), _700);
+  _755 = select((_695 < _685), ((_703 / (exp2((_707 * 1.4426950216293335f) * _705) + 1.0f)) - cb0_038x), _701);
+  _756 = select((_696 < _685), ((_703 / (exp2((_708 * 1.4426950216293335f) * _705) + 1.0f)) - cb0_038x), _702);
+  _763 = _690 - _685;
+  _767 = saturate(_706 / _763);
+  _768 = saturate(_707 / _763);
+  _769 = saturate(_708 / _763);
+  _770 = (_690 < _685);
+  _774 = select(_770, (1.0f - _767), _767);
+  _775 = select(_770, (1.0f - _768), _768);
+  _776 = select(_770, (1.0f - _769), _769);
+  _795 = (((_774 * _774) * (select((_694 > _690), (_665 - (_727 / (exp2(((_694 - _690) * 1.4426950216293335f) * _729) + 1.0f))), _700) - _754)) * (3.0f - (_774 * 2.0f))) + _754;
+  _796 = (((_775 * _775) * (select((_695 > _690), (_665 - (_727 / (exp2(((_695 - _690) * 1.4426950216293335f) * _729) + 1.0f))), _701) - _755)) * (3.0f - (_775 * 2.0f))) + _755;
+  _797 = (((_776 * _776) * (select((_696 > _690), (_665 - (_727 / (exp2(((_696 - _690) * 1.4426950216293335f) * _729) + 1.0f))), _702) - _756)) * (3.0f - (_776 * 2.0f))) + _756;
+  _798 = dot(float3(_795, _796, _797), float3(0.2722287178039551f, 0.6740817427635193f, 0.053689517080783844f));
+  _818 = (cb0_037x * (max(0.0f, (lerp(_798, _795, 0.9300000071525574f))) - _514)) + _514;
+  _819 = (cb0_037x * (max(0.0f, (lerp(_798, _796, 0.9300000071525574f))) - _515)) + _515;
+  _820 = (cb0_037x * (max(0.0f, (lerp(_798, _797, 0.9300000071525574f))) - _516)) + _516;
+  _836 = ((mad(-0.06537103652954102f, _820, mad(1.451815478503704e-06f, _819, (_818 * 1.065374732017517f))) - _818) * cb0_036z) + _818;
+  _837 = ((mad(-0.20366770029067993f, _820, mad(1.2036634683609009f, _819, (_818 * -2.57161445915699e-07f))) - _819) * cb0_036z) + _819;
+  _838 = ((mad(0.9999996423721313f, _820, mad(2.0954757928848267e-08f, _819, (_818 * 1.862645149230957e-08f))) - _820) * cb0_036z) + _820;
+  _860 = max(0.0f, mad((WorkingColorSpace_192[0].z), _838, mad((WorkingColorSpace_192[0].y), _837, ((WorkingColorSpace_192[0].x) * _836))));
+  _861 = max(0.0f, mad((WorkingColorSpace_192[1].z), _838, mad((WorkingColorSpace_192[1].y), _837, ((WorkingColorSpace_192[1].x) * _836))));
+  _862 = max(0.0f, mad((WorkingColorSpace_192[2].z), _838, mad((WorkingColorSpace_192[2].y), _837, ((WorkingColorSpace_192[2].x) * _836))));
+  _888 = cb0_014x * (((cb0_039y + (cb0_039x * _860)) * _860) + cb0_039z);
+  _889 = cb0_014y * (((cb0_039y + (cb0_039x * _861)) * _861) + cb0_039z);
+  _890 = cb0_014z * (((cb0_039y + (cb0_039x * _862)) * _862) + cb0_039z);
+  _911 = exp2(log2(max(0.0f, (lerp(_888, cb0_013x, cb0_013w)))) * cb0_040y);
+  _912 = exp2(log2(max(0.0f, (lerp(_889, cb0_013y, cb0_013w)))) * cb0_040y);
+  _913 = exp2(log2(max(0.0f, (lerp(_890, cb0_013z, cb0_013w)))) * cb0_040y);
+  if (WorkingColorSpace_320 == 0) {
+    _920 = mad((WorkingColorSpace_128[0].z), _913, mad((WorkingColorSpace_128[0].y), _912, ((WorkingColorSpace_128[0].x) * _911)));
+    _923 = mad((WorkingColorSpace_128[1].z), _913, mad((WorkingColorSpace_128[1].y), _912, ((WorkingColorSpace_128[1].x) * _911)));
+    _926 = mad((WorkingColorSpace_128[2].z), _913, mad((WorkingColorSpace_128[2].y), _912, ((WorkingColorSpace_128[2].x) * _911)));
+    _937 = mad(_51, _926, mad(_50, _923, (_920 * _49)));
+    _938 = mad(_54, _926, mad(_53, _923, (_920 * _52)));
+    _939 = mad(_57, _926, mad(_56, _923, (_920 * _55)));
+  } else {
+    _937 = _911;
+    _938 = _912;
+    _939 = _913;
+  }
+  if (_937 < 0.0031306699384003878f) {
+    _950 = (_937 * 12.920000076293945f);
+  } else {
+    _950 = (((pow(_937, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  if (_938 < 0.0031306699384003878f) {
+    _961 = (_938 * 12.920000076293945f);
+  } else {
+    _961 = (((pow(_938, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  if (_939 < 0.0031306699384003878f) {
+    _972 = (_939 * 12.920000076293945f);
+  } else {
+    _972 = (((pow(_939, 0.4166666567325592f)) * 1.0549999475479126f) + -0.054999999701976776f);
+  }
+  u0[int3((int)(SV_DispatchThreadID.x), (int)(SV_DispatchThreadID.y), (int)(SV_DispatchThreadID.z))] = float4((_950 * 0.9523810148239136f), (_961 * 0.9523810148239136f), (_972 * 0.9523810148239136f), 0.0f);
+}

--- a/src/games/ue-extended/shared.h
+++ b/src/games/ue-extended/shared.h
@@ -10,6 +10,7 @@
 #define RENODX_GRAPHICS_WHITE_NITS             shader_injection.graphics_white_nits
 #define RENODX_GAMMA_CORRECTION                shader_injection.gamma_correction
 #define RENODX_GAMMA_CORRECTION_UI             shader_injection.gamma_correction_ui
+#define RENODX_GAMMA_CORRECTION_WORKING_SPACE  shader_injection.gamma_correction_working_space
 #define RENODX_TONE_MAP_HUE_CORRECTION_TYPE    shader_injection.tone_map_hue_correction_type  // 0 - Highlights, Midtones, & Shadows, 1 - Midtones & Shadows
 #define RENODX_TONE_MAP_HUE_CORRECTION         shader_injection.tone_map_hue_correction
 #define RENODX_TONE_MAP_PER_CH_PEAK            shader_injection.tone_map_per_ch_peak
@@ -22,12 +23,14 @@
 #define RENODX_TONE_MAP_HIGHLIGHT_SATURATION   shader_injection.tone_map_highlight_saturation
 #define RENODX_TONE_MAP_BLOWOUT                shader_injection.tone_map_blowout
 #define RENODX_TONE_MAP_CHROMA_CORRECT_BLOWOUT shader_injection.tone_map_chroma_correct_blowout
+#define RENODX_TONE_MAP_HUE_BLOWOUT_WORKING_SPACE 1.f  // ICtCp
 #define RENODX_TONE_MAP_FLARE                  shader_injection.tone_map_flare
 #define RENODX_TONE_MAP_CONTRAST_METHOD        shader_injection.tone_map_contrast_method
 #define CUSTOM_LUT_STRENGTH                    shader_injection.custom_lut_strength
 #define CUSTOM_LUT_SCALING                     shader_injection.custom_lut_scaling
 #define CUSTOM_LUT_SCALING_METHOD              shader_injection.custom_lut_scaling_method
 #define CUSTOM_LUT_GAMUT_RESTORATION           shader_injection.custom_lut_gamut_restoration
+#define CUSTOM_LUT_GAMUT_COMPRESSION_METHOD    1.f  // Adaptive D65
 
 #define CUSTOM_RANDOM         shader_injection.custom_random
 #define CUSTOM_GRAIN_TYPE     shader_injection.custom_grain_type
@@ -93,6 +96,11 @@ struct ShaderInjectData {
   float blend_factor;
 
   float tone_map_hue_restore;
+  float custom_lut_gamut_compression_method;
+  float gamma_correction_working_space;
+  float tone_map_hue_blowout_working_space;
+  float injected_padding1;
+  float injected_padding2;
 };
 
 #ifndef __cplusplus

--- a/src/games/ue-extended/swapchainproxy/swap_chain_proxy_pixel_shader.ps_5_x.hlsl
+++ b/src/games/ue-extended/swapchainproxy/swap_chain_proxy_pixel_shader.ps_5_x.hlsl
@@ -14,12 +14,8 @@ float4 main(float4 vpos: SV_POSITION, float2 uv: TEXCOORD0) : SV_TARGET {
 
   color = renodx::math::ZeroNaN(color);  // Clear NaNs
 
-  [branch]
-  if (RENODX_GAMMA_CORRECTION == 0.f) {
-    color.rgb = renodx::color::srgb::DecodeSafe(color.rgb);
-  } else if (RENODX_GAMMA_CORRECTION == 1.f) {
-    color.rgb = renodx::color::gamma::DecodeSafe(color.rgb);
-  }
+  color.rgb = renodx::color::srgb::DecodeSafe(color.rgb);
+  color.rgb = ApplyGammaCorrection(color.rgb);
 
   // if (RENODX_COLOR_GRADE_SPACE == 1.f) {
   //   color.rgb = renodx::color::bt709::from::BT709D93(color.rgb);


### PR DESCRIPTION
Refactors the Unreal Extended LUT builder pipeline to make LUT scaling and color processing more consistent and maintainable.

Key changes:
- Refactors LUT builder and filmic tonemapping code around the shared processing flow.
- Adds gamut compression for LUT scaling and fixes LMS-path handling.
- Corrects blue treatment for hue/chroma reference processing.
- Adds the AP1 clamp before the filmic stage in the LMS path.
- Includes the associated shader permutations and shared addon updates.