### PR TITLE
feat(ue-extended): hide preset keybinds in simple mode

### DIFF
--- a/src/games/ue-extended/addon.cpp
+++ b/src/games/ue-extended/addon.cpp
@@ -786,7 +786,7 @@ renodx::utils::settings::Settings info_settings = {
           }
           return false;
         },
-        .is_visible = []() { return current_settings_mode >= 0.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
     },
 
     // end keybind code


### PR DESCRIPTION
Follow-up to #110 per Marat's feedback.

Preset keybind UI is now hidden in Simple mode, visible only in Intermediate and above — keeps the simple experience clean.

Tested on HDR and SDR, no crashes, keybinds work, hidden correctly in Simple mode.